### PR TITLE
docs: Sync main branch updates to gh-pages (May 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | [📚 Documentation](#-documentation) | All documentation links and guides |
 | [🚀 Overview](#-overview) | Installation methods comparison |
 | [Getting Started](#getting-started) | Prerequisites and initial setup |
-| [⚡ Quick Installer](#-quick-installer) | Single-command installation |
+| [⚡ Quick Installer 🧪 (Beta)](#-quick-installer) | Single-command beta installation |
 | [📋 Config-Based Installer](#-config-based-installer) | YAML configuration-based installation |
 | [🛠️ Config-Based Installation Steps](#️-config-based-installation-steps) | Step-by-step configuration guide |
 | [🌐 Multi-Cluster Setup](#-multi-cluster-setup) | Multi-cluster deployment guide |
@@ -28,7 +28,7 @@
 | Category | Document | Description |
 |----------|----------|-------------|
 | **🔑 License** | [EGS License Setup](docs/EGS-License-Setup.html) | License configuration guide |
-| **⚡ Quick Start** | [Quick Install Guide](docs/Quick-Install-README.html) | Single-command installer with all options |
+| **⚡ Quick Start 🧪 (Beta)** | [Quick Install Guide](docs/Quick-Install-README.html) | Single-command beta installer with all options |
 | **📋 Configuration** | [Configuration Reference](docs/Configuration-README.html) | Config-based installer detailed reference |
 | **🌐 Multi-Cluster** | [Multi-Cluster Example](multi-cluster-example.yaml) | Complete multi-cluster YAML example |
 | **📋 Prerequisites** | [Controller Prerequisites](docs/EGS-Controller-Prerequisites.html) | Controller cluster requirements |
@@ -51,7 +51,7 @@ The EGS Installer provides installation methods for deploying EGS components int
 
 | Method | Best For | Description | Documentation |
 |--------|----------|-------------|---------------|
-| **⚡ Quick Installer** | New users, PoC, simple setups | Single-command installer with auto-configuration, skip flags, and multi-cluster support | **[📖 Quick Install Guide](docs/Quick-Install-README.html)** |
+| **⚡ Quick Installer 🧪 (Beta)** | New users, PoC, simple setups | **Beta** single-command installer with auto-configuration, skip flags, and multi-cluster support | **[📖 Quick Install Guide](docs/Quick-Install-README.html)** |
 | **📋 Config-Based Installer** | Production, teams, advanced setups | Version-controlled YAML configuration for repeatable, auditable installs | **[📖 Configuration Reference](docs/Configuration-README.html)** |
 
 All methods leverage **Helm** for package management, **kubectl** for Kubernetes interaction, and **yq** for YAML parsing.
@@ -129,6 +129,8 @@ For clusters with namespace policies:
 ---
 
 ## ⚡ Quick Installer
+
+> 🧪 **Beta:** The Quick Installer is currently in **beta**. For production or advanced setups, prefer the **Config-Based Installer** below.
 
 > **New to EGS?** Start here with our single-command installer!
 

--- a/docs/EGS-License-Setup.md
+++ b/docs/EGS-License-Setup.md
@@ -185,7 +185,7 @@ EGS offers different license tiers:
 
 After successfully applying the license:
 
-1. **Install KubeSlice Controller**: Follow the [EGS Controller Prerequisites](EGS-Controller-Prerequisites.html) guide
+1. **Install KubeSlice Controller**: Follow the [EGS Controller Prerequisites](EGS-Controller-Prerequisites.md) guide
 2. **Configure Monitoring**: Set up Prometheus and PostgreSQL as outlined in the prerequisites
 3. **Deploy EGS Components**: Install the controller and worker components
 4. **Verify Operation**: Ensure all components are functioning with the applied license
@@ -193,8 +193,8 @@ After successfully applying the license:
 ## Additional Resources
 
 - [EGS Registration Portal](https://avesha.io/egs-registration)
-- [EGS Controller Prerequisites](EGS-Controller-Prerequisites.html)
-- [EGS Worker Prerequisites](EGS-Worker-Prerequisites.html)
+- [EGS Controller Prerequisites](EGS-Controller-Prerequisites.md)
+- [EGS Worker Prerequisites](EGS-Worker-Prerequisites.md)
 - [KubeSlice Documentation](https://docs.avesha.io)
 - [Avesha Support Portal](https://support.avesha.io)
 

--- a/docs/EGS-License-Setup.md
+++ b/docs/EGS-License-Setup.md
@@ -185,7 +185,7 @@ EGS offers different license tiers:
 
 After successfully applying the license:
 
-1. **Install KubeSlice Controller**: Follow the [EGS Controller Prerequisites](EGS-Controller-Prerequisites.md) guide
+1. **Install KubeSlice Controller**: Follow the [EGS Controller Prerequisites](EGS-Controller-Prerequisites.html) guide
 2. **Configure Monitoring**: Set up Prometheus and PostgreSQL as outlined in the prerequisites
 3. **Deploy EGS Components**: Install the controller and worker components
 4. **Verify Operation**: Ensure all components are functioning with the applied license
@@ -193,8 +193,8 @@ After successfully applying the license:
 ## Additional Resources
 
 - [EGS Registration Portal](https://avesha.io/egs-registration)
-- [EGS Controller Prerequisites](EGS-Controller-Prerequisites.md)
-- [EGS Worker Prerequisites](EGS-Worker-Prerequisites.md)
+- [EGS Controller Prerequisites](EGS-Controller-Prerequisites.html)
+- [EGS Worker Prerequisites](EGS-Worker-Prerequisites.html)
 - [KubeSlice Documentation](https://docs.avesha.io)
 - [Avesha Support Portal](https://support.avesha.io)
 

--- a/docs/EGS-Worker-Prerequisites.md
+++ b/docs/EGS-Worker-Prerequisites.md
@@ -582,6 +582,42 @@ kubectl port-forward svc/prometheus-grafana 3000:80 -n egs-monitoring
 # Default credentials: admin / prom-operator
 # Import dashboard ID: 12239 (NVIDIA GPU Exporter Dashboard)
 ```
+### 3.4 Service Monitor for Latency Metrics
+
+Create a ServiceMonitor to scrape Latency metrics:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: gateway-pods-podmonitor
+  namespace: egs-monitoring
+  labels:
+    release: prometheus
+spec:
+  namespaceSelector:
+    matchNames:
+      - kubeslice-system
+  podMetricsEndpoints:
+    - port: metrics   # Numeric ports should be quoted
+      path: /metrics
+      interval: 30s
+      scheme: http
+  selector:
+    matchLabels:
+      kubeslice.io/pod-type: slicegateway
+
+```
+
+### 3.5 Apply Monitoring Configuration
+
+```bash
+# Apply the PodMonitor
+kubectl apply -f pod-monitor.yaml
+
+# Verify the monitors are created
+kubectl get podmonitor -n egs-monitoring
+```
 
 ## 4. Verification Steps
 

--- a/docs/Quick-Install-README.md
+++ b/docs/Quick-Install-README.md
@@ -1673,7 +1673,7 @@ curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash
 ## 📚 Related Documentation
 
 - 📋 [EGS License Setup](EGS-License-Setup.html) - How to obtain and configure your license
-- 🛠️ [Full Installation Guide](../README.html#getting-started) - For multi-cluster and advanced setups
+- 🛠️ [Full Installation Guide](../README.md#getting-started) - For multi-cluster and advanced setups
 - 📊 [Configuration Documentation](Configuration-README.html) - Detailed configuration options
 - ✅ [Preflight Check](EGS-Preflight-Check-README.html) - Validate your environment before installation
 - 🌐 [EGS User Guide](https://docs.avesha.io/documentation/enterprise-egs) - Complete product documentation

--- a/egs-install-prerequisites.sh
+++ b/egs-install-prerequisites.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the script version
-SCRIPT_VERSION="1.15.3"
+SCRIPT_VERSION="1.17.1"
 
 # Check if the script is running in Bash
 if [ -z "$BASH_VERSION" ]; then
@@ -407,7 +407,7 @@ parse_yaml() {
     READD_HELM_REPOS=$(yq e '.readd_helm_repos' "$yaml_file")
 
     # Extract global imagePullSecrets settings
-    GLOBAL_IMAGE_PULL_SECRET_REPO=$(yq e '.global_image_pull_secret.repository' "$yaml_file")
+    GLOBAL_IMAGE_PULL_SECRET_REPO=$(yq e '.global_image_pull_secret.registry' "$yaml_file")
     GLOBAL_IMAGE_PULL_SECRET_USERNAME=$(yq e '.global_image_pull_secret.username' "$yaml_file")
     GLOBAL_IMAGE_PULL_SECRET_PASSWORD=$(yq e '.global_image_pull_secret.password' "$yaml_file")
     GLOBAL_IMAGE_PULL_SECRET_EMAIL=$(yq e '.global_image_pull_secret.email' "$yaml_file")
@@ -1314,8 +1314,16 @@ install_or_upgrade_helm_chart() {
         chart_name="$local_charts_path/$chart_name"
         echo "🗂️  Using local chart at path '$chart_name'..."
     elif [ -n "$repo_url" ]; then
-        manage_helm_repo "$repo_url" "$username" "$password"
-        chart_name="temp-repo/$chart_name"
+        # Check if the repo_url is an OCI registry
+        if [[ "$repo_url" =~ ^oci:// ]]; then
+            # For OCI registries, use the full OCI URL directly
+            chart_name="$repo_url"
+            echo "🗂️  Using OCI registry chart at '$chart_name'..."
+        else
+            # For regular Helm repositories, add the repo and use temp-repo prefix
+            manage_helm_repo "$repo_url" "$username" "$password"
+            chart_name="temp-repo/$chart_name"
+        fi
     fi
 
     # Create the namespace if it doesn't exist
@@ -1511,8 +1519,8 @@ EOF
     echo "✅ Helm chart '$release_name' processed successfully in namespace '$namespace'."
     echo ""
 
-    # Remove the temporary Helm repository if added
-    if [ "$use_local_charts_effective" != "true" ] && [ -n "$repo_url" ]; then
+    # Remove the temporary Helm repository if added (skip for OCI registries)
+    if [ "$use_local_charts_effective" != "true" ] && [ -n "$repo_url" ] && [[ ! "$repo_url" =~ ^oci:// ]]; then
         helm repo remove temp-repo
     fi
 

--- a/egs-installer-config.yaml
+++ b/egs-installer-config.yaml
@@ -31,7 +31,7 @@ run_commands: false
 
 # Global image pull secret settings for AirGap Installations
 global_image_pull_secret:
-  repository: "https://index.docker.io/v1/"   # Docker registry URL
+  registry: "https://index.docker.io/v1/"   # Docker registry URL
   username: ""                                # Global Docker registry username
   password: ""                                # Global Docker registry password
 
@@ -44,11 +44,11 @@ enable_autofetch_egsagent_endpoint_and_token: true # if False then, skip update 
 # Global monitoring endpoint settings
 global_auto_fetch_endpoint: true               # Enable automatic fetching of monitoring endpoints globally
 global_grafana_namespace: egs-monitoring        # Namespace where Grafana is globally deployed
-global_grafana_service_type: ClusterIP          # Service type for Grafana (accessible only within the cluster)
+global_grafana_service_type: NodePort          # Service type for Grafana (accessible only within the cluster)
 global_grafana_service_name: prometheus-grafana # Service name for accessing Grafana globally
 global_prometheus_namespace: egs-monitoring     # Namespace where Prometheus is globally deployed
 global_prometheus_service_name: prometheus-kube-prometheus-prometheus # Service name for accessing Prometheus globally
-global_prometheus_service_type: ClusterIP       # Service type for Prometheus (accessible only within the cluster)
+global_prometheus_service_type: NodePort       # Service type for Prometheus (accessible only within the cluster)
 
 # Precheck options
 precheck: true                                  # Run general prechecks before starting the installation
@@ -105,6 +105,27 @@ kubeslice_controller_egs:
     kubeslice:
       controller:
         endpoint: ""                           # Endpoint of the controller API server; auto-fetched if left empty
+        replication:
+          minio:
+            # Whether to install MinIO
+            install: "false"
+            # Storage size for MinIO
+            storage: 1Gi
+            # Username for MinIO
+            username: minioadmin
+            # Password for MinIO
+            password: minioadmin
+            # service options
+            service:
+              # minio service type
+              type: "NodePort"
+    # ServiceMonitor configuration for Prometheus monitoring
+    serviceMonitor:
+      # Enable or disable ServiceMonitor deployment
+      enabled: true
+      # Namespace where ServiceMonitor will be deployed
+      namespace: egs-monitoring
+
 #### Helm Flags and Verification Settings ####
   helm_flags: "--wait --timeout 5m --debug"            # Additional Helm flags for the installation
   verify_install: false                        # Verify the installation of the controller
@@ -132,7 +153,7 @@ kubeslice_ui_egs:
         url: http://prometheus-kube-prometheus-prometheus.egs-monitoring.svc.cluster.local:9090  # Prometheus URL for monitoring
       uiproxy:
         service:
-          type: LoadBalancer                  # Service type for the UI proxy
+          type: NodePort                  # Service type for the UI proxy
           ## if type selected to NodePort then set nodePort value if required
           # nodePort:
           # port: 443
@@ -164,7 +185,7 @@ kubeslice_ui_egs:
       apigw:
         env:
           - name: DCGM_METRIC_JOB_VALUE
-            value: nvidia-dcgm-exporter
+            value: gpu-metrics
           
       egsCoreApis:
         enabled: true                         # Enable EGS core APIs for the UI
@@ -223,6 +244,10 @@ kubeslice_worker_egs:
             value: "nvidia-dcgm.egs-gpu-operator.svc.cluster.local:5555"
           - name: HEALTH_CHECK_INTERVAL
             value: "15m"
+      monitoring:
+        podMonitor:
+          enabled: true
+          namespace: egs-monitoring
 #### Helm Flags and Verification Settings ####
     helm_flags: "--wait --timeout 5m --debug"          # Additional Helm flags for the worker installation
     verify_install: true                       # Verify the installation of the worker
@@ -271,7 +296,7 @@ additional_apps:
     release: "gpu-operator"                    # Helm release name for the GPU operator
     chart: "gpu-operator"                      # Helm chart name for the GPU operator
     repo_url: "https://helm.ngc.nvidia.com/nvidia" # Helm repository URL for the GPU operator
-    version: "v24.9.1"                         # Version of the GPU operator to install
+    version: "v25.3.4"                         # Version of the GPU operator to install
     specific_use_local_charts: true            # Use local charts for this application
     #### Inline Helm Values for GPU Operator ####
     inline_values:
@@ -312,18 +337,18 @@ additional_apps:
     inline_values:
       prometheus:
         service:
-          type: ClusterIP                     # Service type for Prometheus
+          type: NodePort                     # Service type for Prometheus
         prometheusSpec:
           storageSpec: {}                     # Placeholder for storage configuration
           additionalScrapeConfigs:
-          - job_name: nvidia-dcgm-exporter
-            kubernetes_sd_configs:
-            - role: endpoints
-            relabel_configs:
-            - source_labels: [__meta_kubernetes_pod_name]
-              target_label: pod_name
-            - source_labels: [__meta_kubernetes_pod_container_name]
-              target_label: container_name
+          # - job_name: nvidia-dcgm-exporter
+          #   kubernetes_sd_configs:
+          #   - role: endpoints
+          #   relabel_configs:
+          #   - source_labels: [__meta_kubernetes_pod_name]
+          #     target_label: pod_name
+          #   - source_labels: [__meta_kubernetes_pod_container_name]
+          #     target_label: container_name
           - job_name: gpu-metrics
             scrape_interval: 1s
             metrics_path: /metrics
@@ -333,6 +358,7 @@ additional_apps:
               namespaces:
                 names:
                 - egs-gpu-operator
+                - gpu-operator
             relabel_configs:
             - source_labels: [__meta_kubernetes_endpoints_name]
               action: drop
@@ -350,7 +376,7 @@ additional_apps:
             enabled: true
             org_role: Viewer
         service:
-          type: ClusterIP                  # Service type for Grafana
+          type: NodePort                  # Service type for Grafana
         persistence:
           enabled: false                      # Disable persistence
           size: 1Gi                           # Default persistence size
@@ -369,7 +395,7 @@ additional_apps:
     release: "kt-postgresql"                  # Helm release name for PostgreSQL
     chart: "postgresql"                       # Helm chart name for PostgreSQL
     repo_url: "oci://registry-1.docker.io/bitnamicharts/postgresql" # Helm repository URL for PostgreSQL
-    version: "16.2.1"                         # Version of the PostgreSQL chart to install
+    version: "16.7.27"                         # Version of the PostgreSQL chart to install
     specific_use_local_charts: true           # Use local charts for this application
     values_file: ""                            # Path to an external values file, if any
     #### Inline Helm Values for PostgreSQL ####
@@ -381,12 +407,38 @@ additional_apps:
         database: "postgres"                  # Default database to create
       primary:
         persistence:
-          enabled: false                      # Disable persistent storage for PostgreSQL
+          enabled: true                      # Disable persistent storage for PostgreSQL
           size: 10Gi                          # Size of the Persistent Volume Claim
     helm_flags: "--wait --debug"                       # Additional Helm flags for this application's installation
     verify_install: true                       # Verify the installation of PostgreSQL
     verify_install_timeout: 600                # Timeout for verification (in seconds)
     skip_on_verify_fail: false                 # Do not skip if verification fails
+
+  - name: "envoy-gateway"                      # Name of the application
+    skip_installation: false                   # Do not skip the installation of Envoy Gateway
+    use_global_kubeconfig: true                # Use global kubeconfig for Envoy Gateway
+    kubeconfig: ""                             # Path to the kubeconfig file specific to this application
+    kubecontext: ""                            # Kubecontext specific to this application; uses global context if empty
+    namespace: "envoy-gateway-system"          # Namespace where Envoy Gateway will be installed
+    release: "eg"                              # Helm release name for Envoy Gateway
+    chart: "gateway-helm"                      # Helm chart name for Envoy Gateway
+    repo_url: ""                               # Empty for local charts
+    version: "1.6.2"                           # Version of the Envoy Gateway chart (matches pulled chart)
+    specific_use_local_charts: true            # Use local charts from charts directory
+    values_file: ""                            # Path to an external values file, if any
+    #### Inline Helm Values for Envoy Gateway ####
+    inline_values:
+      config:
+        envoyGateway:
+          provider:
+            kubernetes:
+              deploy:
+                type: "GatewayNamespace"       # Configure deployment type as GatewayNamespace
+    helm_flags: "--create-namespace --debug"   # Additional Helm flags for this application's installation
+    verify_install: false                      # Verify the installation of Envoy Gateway
+    verify_install_timeout: 600                # Timeout for verification (in seconds)
+    skip_on_verify_fail: true                  # Skip the step if verification fails
+    enable_troubleshoot: false                 # Enable troubleshooting mode for additional logs and checks
 
 
 #### Define Custom Applications and Associated Manifests ####
@@ -496,4 +548,4 @@ required_binaries:
 #### Node Labeling Settings ####
 add_node_label: true                        # Enable node labeling during installation
 # Version of the input configuration file
-version: "1.15.3"
+version: "1.17.1"

--- a/egs-installer.sh
+++ b/egs-installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the script version
-SCRIPT_VERSION="1.17.0"
+SCRIPT_VERSION="1.17.1"
 
 # Check if the script is running in Bash
 if [ -z "$BASH_VERSION" ]; then

--- a/egs-only-config.yaml
+++ b/egs-only-config.yaml
@@ -2,7 +2,7 @@
 
 # Global image pull secret settings
 global_image_pull_secret:
-  repository: "https://index.docker.io/v1/"   # Docker registry URL
+  registry: "https://index.docker.io/v1/"   # Docker registry URL
   username: ""                                # Global Docker registry username
   password: ""                                # Global Docker registry password
 
@@ -46,6 +46,26 @@ kubeslice_controller_egs:
     kubeslice:
       controller:
         endpoint: ""                           # Endpoint of the controller API server; auto-fetched if left empty
+        replication:
+          minio:
+            # Whether to install MinIO
+            install: "false"
+            # Storage size for MinIO
+            storage: 1Gi
+            # Username for MinIO
+            username: minioadmin
+            # Password for MinIO
+            password: minioadmin
+            # service options
+            service:
+              # minio service type
+              type: "NodePort"
+    # ServiceMonitor configuration for Prometheus monitoring
+    serviceMonitor:
+      # Enable or disable ServiceMonitor deployment
+      enabled: true
+      # Namespace where ServiceMonitor will be deployed
+      namespace: egs-monitoring
 #### Helm Flags and Verification Settings ####
   helm_flags: "--wait --timeout 5m --debug"            # Additional Helm flags for the installation
   verify_install: false                        # Verify the installation of the controller
@@ -73,7 +93,7 @@ kubeslice_ui_egs:
         url: http://prometheus-kube-prometheus-prometheus.egs-monitoring.svc.cluster.local:9090  # Prometheus URL for monitoring
       uiproxy:
         service:
-          type: LoadBalancer                  # Service type for the UI proxy
+          type: NodePort                  # Service type for the UI proxy
           ## if type selected to NodePort then set nodePort value if required
           # nodePort:
           # port: 443
@@ -105,7 +125,7 @@ kubeslice_ui_egs:
       apigw:
         env:
           - name: DCGM_METRIC_JOB_VALUE
-            value: nvidia-dcgm-exporter
+            value: gpu-metrics
       egsCoreApis:
         enabled: true                         # Enable EGS core APIs for the UI
         service:
@@ -163,6 +183,10 @@ kubeslice_worker_egs:
             value: "nvidia-dcgm.egs-gpu-operator.svc.cluster.local:5555"
           - name: HEALTH_CHECK_INTERVAL
             value: "15m"
+      monitoring:
+        podMonitor:
+          enabled: true
+          namespace: egs-monitoring
 #### Helm Flags and Verification Settings ####
     helm_flags: "--wait --timeout 5m --debug"          # Additional Helm flags for the worker installation
     verify_install: true                       # Verify the installation of the worker
@@ -204,7 +228,7 @@ required_binaries:
 #### Node Labeling Settings ####
 add_node_label: true                        # Enable node labeling during installation
 # Version of the input configuration file
-version: "1.15.3"
+version: "1.17.1"
 
 # Enable or disable specific stages of the installation
 enable_install_controller: true               # Enable the installation of the Kubeslice controller

--- a/egs-preflight-check.sh
+++ b/egs-preflight-check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the script version
-SCRIPT_VERSION="1.15.3"
+SCRIPT_VERSION="1.17.1"
 
 # Global Configuration and Constants
 readonly MAX_TIMEOUT=30

--- a/egs-uninstall.sh
+++ b/egs-uninstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the script version
-SCRIPT_VERSION="1.15.3"
+SCRIPT_VERSION="1.17.1"
 
 # Check if the script is running in Bash
 if [ -z "$BASH_VERSION" ]; then
@@ -709,7 +709,7 @@ parse_yaml() {
     READD_HELM_REPOS=$(yq e '.readd_helm_repos' "$yaml_file")
 
     # Extract global imagePullSecrets settings
-    GLOBAL_IMAGE_PULL_SECRET_REPO=$(yq e '.global_image_pull_secret.repository' "$yaml_file")
+    GLOBAL_IMAGE_PULL_SECRET_REPO=$(yq e '.global_image_pull_secret.registry' "$yaml_file")
     GLOBAL_IMAGE_PULL_SECRET_USERNAME=$(yq e '.global_image_pull_secret.username' "$yaml_file")
     GLOBAL_IMAGE_PULL_SECRET_PASSWORD=$(yq e '.global_image_pull_secret.password' "$yaml_file")
     GLOBAL_IMAGE_PULL_SECRET_EMAIL=$(yq e '.global_image_pull_secret.email' "$yaml_file")


### PR DESCRIPTION
## Summary

Sync the latest installer documentation and scripts from `main` into `gh-pages` so the public docs site at https://repo.egs.avesha.io/ reflects the current state of the Quick Installer and related guides.

## Files Synced From `main`

| File | What changed |
|------|--------------|
| `README.md` | Quick Installer Beta branding + new Beta callout block |
| `docs/Quick-Install-README.md` | Latest Beta guide content |
| `docs/EGS-License-Setup.md` | License setup updates |
| `docs/EGS-Worker-Prerequisites.md` | New worker prerequisite content (+36 lines) |
| `egs-installer.sh` | Latest installer script |
| `egs-install-prerequisites.sh` | Latest prerequisites installer |
| `egs-installer-config.yaml` | Updated config defaults (MinIO disabled, latest values) |
| `egs-only-config.yaml` | Updated EGS-only config |
| `egs-preflight-check.sh` | Latest preflight script |
| `egs-uninstall.sh` | Latest uninstall script |

## Gh-pages Conventions Preserved

- All cross-references between docs use `.html` extensions (Jekyll rendering)
- Jekyll/site files untouched: `CNAME`, `_config.yml`, `_layouts/`, `assets/css/`, `Gemfile`, `index.md`
- Chart binaries (`charts/*`) intentionally not synced — gh-pages is doc-only

## Verification

Working tree differs from `origin/main` only in 4 doc files where internal links use `.html` instead of `.md` — required by Jekyll on gh-pages. Content is otherwise byte-identical to `main`.

## Test Plan

- [ ] Verify GitHub Pages build succeeds after merge
- [ ] Spot-check rendered pages at https://repo.egs.avesha.io/
  - [ ] Quick Install Guide renders with Beta callout
  - [ ] Worker Prerequisites includes new content
  - [ ] All doc-to-doc links resolve (no 404s)