### PR TITLE
Add RKE Controller and Worker installation guides to poc/

### DIFF
--- a/poc/EGS-RKE-Controller-Install-Guide.md
+++ b/poc/EGS-RKE-Controller-Install-Guide.md
@@ -1,0 +1,416 @@
+# EGS Standalone Controller — Installation Guide for RKE Clusters
+
+> **Based on:** EGS Quick Install v1.0 | Rancher Kubernetes Engine (RKE)  
+> **Scope:** Single-cluster, Controller + UI only — Worker omitted
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Prerequisites](#2-prerequisites)
+3. [RKE-Specific Considerations](#3-rke-specific-considerations)
+4. [Installation](#4-installation)
+5. [What the Installer Does](#5-what-the-installer-does)
+6. [Post-Install Verification](#6-post-install-verification)
+7. [Troubleshooting](#7-troubleshooting)
+8. [Next Steps](#8-next-steps)
+
+---
+
+## 1. Overview
+
+This guide covers installing the EGS Controller (and optionally the EGS UI) as a standalone deployment on a Rancher Kubernetes Engine (RKE) cluster. The EGS Worker is intentionally omitted — use these instructions when you want a dedicated control-plane cluster that will later register remote worker clusters.
+
+The EGS Quick Installer (`install-egs.sh`) is the recommended approach. It auto-detects cluster capabilities, generates an `egs-installer-config.yaml`, and handles prerequisites such as PostgreSQL, Prometheus, and the GPU Operator.
+
+### What Will Be Installed
+
+| Component | Namespace | Notes |
+|-----------|-----------|-------|
+| PostgreSQL | `kt-postgresql` | Backing store for the Controller |
+| Prometheus Stack | `egs-monitoring` | Metrics and PodMonitor CRDs |
+| GPU Operator | `egs-gpu-operator` | Skip with `--skip-gpu-operator` on CPU-only nodes |
+| EGS Controller | `kubeslice-controller` | Required |
+| EGS UI | `kubeslice-controller` | Optional; omit with `--skip-ui` |
+
+### What Will NOT Be Installed
+
+- **EGS Worker** — excluded via `--skip-worker`
+- Any second or worker cluster components
+
+---
+
+## 2. Prerequisites
+
+### 2.1 RKE Cluster Requirements
+
+- RKE version v1.3+ (Kubernetes v1.23.6 or newer on the underlying nodes)
+- Admin-level kubeconfig with access to the target RKE cluster
+- Nodes: minimum 3 nodes recommended for production; 1-node acceptable for PoC
+- UI access: the UI proxy service defaults to `NodePort` (reachable at `https://<node-ip>:<nodePort>`), which works out-of-the-box on bare-metal RKE. Pass `--ui-service-type LoadBalancer` only if a cloud LB or MetalLB is available
+
+### 2.2 Required CLI Tools
+
+Verify each tool is installed and at the required version before running the installer:
+
+| Tool | Min Version | Verify Command |
+|------|-------------|----------------|
+| `kubectl` | v1.23.6+ | `kubectl version --client` |
+| `helm` | v3.15.0+ | `helm version` |
+| `yq` | v4.44.2+ | `yq --version` |
+| `jq` | v1.6+ | `jq --version` |
+| `git` | Any recent | `git --version` |
+| `curl` | Any recent | `curl --version` |
+
+### 2.3 EGS License File
+
+> **Note:** A valid EGS license file (`egs-license.yaml`) is required **only when installing the Controller**. It is not required for prerequisites alone, the UI, or Worker.
+
+To obtain a license:
+
+1. Go to <https://avesha.io/egs-registration> and complete the registration form.
+2. Generate your cluster fingerprint from the RKE cluster:
+   ```bash
+   kubectl get namespace kube-system \
+     -o=jsonpath='{.metadata.creationTimestamp}{.metadata.uid}{"\n"}'
+   ```
+3. Submit the fingerprint during registration and receive `egs-license.yaml` via email.
+4. Place the file in the directory from which you will run the installer, or note its full path.
+
+---
+
+## 3. RKE-Specific Considerations
+
+### 3.1 Kubeconfig Location
+
+RKE generates a kubeconfig at `kube_config_cluster.yml` (or `kube_config_<cluster-name>.yml`) in the same directory where `rke up` was executed. Export this path before running the installer:
+
+```bash
+# Typical RKE kubeconfig location
+export KUBECONFIG=/path/to/kube_config_cluster.yml
+
+# Verify connectivity
+kubectl get nodes
+```
+
+### 3.2 No Cloud Provider — UI Service Type
+
+> **Note:** The EGS UI proxy defaults to `NodePort`, so it works on bare-metal RKE clusters with no cloud LoadBalancer — no extra flags required. Access it at `https://<node-ip>:<nodePort>`.
+
+If you are running MetalLB or another LB provider and prefer an external IP, pass `--ui-service-type LoadBalancer` explicitly. Use `--ui-service-type ClusterIP` to keep the UI internal-only.
+
+### 3.3 GPU Operator on RKE
+
+If your RKE nodes have no NVIDIA GPUs, skip the GPU Operator entirely with `--skip-gpu-operator`. The installer auto-detects GPU capacity; however, explicitly skipping avoids unnecessary wait time on CPU-only clusters.
+
+### 3.4 Gateway Node Labeling — Not Applicable (Controller-Only)
+
+> **Note:** Gateway node labeling (`kubeslice.io/node-type=gateway`) is driven by the **EGS Worker** installation, not the Controller. The installer applies the label inside its worker pre-check — and only for a worker whose installation is **not** skipped (`egs-installer.sh`, worker loop). The Controller chart does not schedule slice-gateway or `kubeslice-dns` pods, so it needs no gateway node.
+>
+> Because this guide uses `--skip-worker`, the worker entry is marked `skip_installation=true`, the pre-check takes the "skipping" branch, and **no gateway labeling occurs** — no manual action is needed.
+>
+> ℹ️ In a *full* single-cluster install where the Worker is co-located with the Controller (i.e., **without** `--skip-worker`), that same shared node **does** get labeled — but it is the Worker install that triggers it. Gateway labeling becomes relevant when you register/install a worker cluster (see [Section 8](#8-next-steps)).
+
+---
+
+## 4. Installation
+
+### 4.1 Scenario A — Fresh Install (All Prerequisites)
+
+Use this when PostgreSQL, Prometheus, and GPU Operator are not yet installed on the RKE cluster. This is the most common path for a new cluster.
+
+#### GPU Cluster (with NVIDIA nodes)
+
+```bash
+# ============ CUSTOMIZE THESE VALUES ============
+export LICENSE_FILE="egs-license.yaml"          # Path to your license file
+export KUBECONFIG_PATH="/path/to/kube_config_cluster.yml"
+export CLUSTER_NAME="rke-controller"            # Logical name for this cluster
+
+# ============ RUN THE INSTALLER ============
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --license-file $LICENSE_FILE \
+  --kubeconfig $KUBECONFIG_PATH \
+  --cluster-name $CLUSTER_NAME \
+  --skip-worker
+```
+
+#### CPU-Only RKE Cluster (No GPUs)
+
+```bash
+# ============ CUSTOMIZE THESE VALUES ============
+export LICENSE_FILE="egs-license.yaml"
+export KUBECONFIG_PATH="/path/to/kube_config_cluster.yml"
+export CLUSTER_NAME="rke-controller"
+
+# ============ RUN THE INSTALLER ============
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --license-file $LICENSE_FILE \
+  --kubeconfig $KUBECONFIG_PATH \
+  --cluster-name $CLUSTER_NAME \
+  --skip-worker \
+  --skip-gpu-operator
+```
+
+#### CPU-Only RKE + Explicit NodePort UI
+
+> **Note:** `NodePort` is already the default UI service type, so the `--ui-service-type NodePort` flag below is **optional** — include it only if you want to be explicit. Use `--ui-service-type LoadBalancer` instead if you have MetalLB or a cloud LB.
+
+```bash
+# ============ CUSTOMIZE THESE VALUES ============
+export LICENSE_FILE="egs-license.yaml"
+export KUBECONFIG_PATH="/path/to/kube_config_cluster.yml"
+export CLUSTER_NAME="rke-controller"
+
+# ============ RUN THE INSTALLER ============
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --license-file $LICENSE_FILE \
+  --kubeconfig $KUBECONFIG_PATH \
+  --cluster-name $CLUSTER_NAME \
+  --skip-worker \
+  --skip-gpu-operator \
+  --ui-service-type NodePort
+```
+
+---
+
+### 4.2 Scenario B — Skip Prerequisites (Already Installed)
+
+Use this when PostgreSQL, Prometheus, and GPU Operator are already running on the RKE cluster (e.g., upgrading EGS or re-installing after a failed run).
+
+```bash
+# ============ CUSTOMIZE THESE VALUES ============
+export LICENSE_FILE="egs-license.yaml"
+export KUBECONFIG_PATH="/path/to/kube_config_cluster.yml"
+export CLUSTER_NAME="rke-controller"
+
+# ============ RUN THE INSTALLER ============
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --license-file $LICENSE_FILE \
+  --kubeconfig $KUBECONFIG_PATH \
+  --cluster-name $CLUSTER_NAME \
+  --skip-postgresql \
+  --skip-prometheus \
+  --skip-gpu-operator \
+  --skip-worker
+```
+
+---
+
+### 4.3 Scenario C — Controller Only (No UI)
+
+Use this for a headless controller-only deployment — useful in automation pipelines where UI access is not needed.
+
+```bash
+# ============ CUSTOMIZE THESE VALUES ============
+export LICENSE_FILE="egs-license.yaml"
+export KUBECONFIG_PATH="/path/to/kube_config_cluster.yml"
+export CLUSTER_NAME="rke-controller"
+
+# ============ RUN THE INSTALLER ============
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --license-file $LICENSE_FILE \
+  --kubeconfig $KUBECONFIG_PATH \
+  --cluster-name $CLUSTER_NAME \
+  --skip-prometheus \
+  --skip-gpu-operator \
+  --skip-worker \
+  --skip-ui
+```
+
+> **Note:** Prometheus CRDs (`PodMonitor`) are still needed by the Controller. Only skip Prometheus if you have already installed the `kube-prometheus-stack` separately.
+
+---
+
+### 4.4 Override Flags Quick Reference
+
+| Flag | Effect | Use When |
+|------|--------|----------|
+| `--skip-postgresql` | Skip PostgreSQL (if already installed) | Upgrading or PostgreSQL exists |
+| `--skip-prometheus` | Skip Prometheus stack | When Prometheus already deployed |
+| `--skip-gpu-operator` | Skip NVIDIA GPU Operator | CPU-only RKE cluster or GPU already configured |
+| `--skip-worker` | Skip EGS Worker installation | Installing standalone Controller only |
+| `--skip-ui` | Skip EGS UI installation | Headless / controller-only deployment |
+| `--ui-service-type TYPE` | Set UI proxy service type: `NodePort` (default), `LoadBalancer`, or `ClusterIP` | Use `LoadBalancer` only when MetalLB/cloud LB exists |
+
+---
+
+## 5. What the Installer Does
+
+The following steps execute automatically in order during a standard standalone controller install:
+
+1. Downloads `install-egs.sh` and supporting scripts from `repo.egs.avesha.io`
+2. Clones the `egs-installation` repository internally
+3. Auto-detects GPU nodes via `kubectl get nodes` and sets `enable_custom_apps` accordingly
+4. Auto-detects cloud provider from node `providerID` (left empty for bare-metal RKE)
+5. Generates `egs-installer-config.yaml` in the working directory
+6. Applies the EGS license to the `kubeslice-controller` namespace
+7. Installs PostgreSQL in the `kt-postgresql` namespace (unless `--skip-postgresql`)
+8. Installs Prometheus Stack in the `egs-monitoring` namespace (unless `--skip-prometheus`)
+9. Installs GPU Operator in the `egs-gpu-operator` namespace (unless `--skip-gpu-operator`)
+10. Installs EGS Controller in the `kubeslice-controller` namespace
+11. Installs EGS UI in the `kubeslice-controller` namespace (unless `--skip-ui`)
+12. Prints the UI access URL and admin token to the terminal
+
+> **Note:** The installer writes the following files to your working directory: `egs-installer-config.yaml`, `egs-installer.sh`, `egs-install-prerequisites.sh`, `egs-uninstall.sh`, and a `charts/` directory. Keep these for future upgrades or uninstallation.
+
+---
+
+## 6. Post-Install Verification
+
+### 6.1 Check Component Status
+
+```bash
+# Verify Controller pods are running
+kubectl get pods -n kubeslice-controller
+
+# Verify PostgreSQL
+kubectl get pods -n kt-postgresql
+
+# Verify Prometheus
+kubectl get pods -n egs-monitoring
+
+# Verify all Helm releases
+helm list -A
+```
+
+### 6.2 Retrieve UI Access Details
+
+The installer prints the UI URL and token at the end of the run. To retrieve them manually:
+
+#### Get the UI URL
+
+```bash
+kubectl get svc kubeslice-ui-proxy -n kubeslice-controller
+# Default (NodePort): the PORT(S) column shows 443:<nodePort>/TCP
+#   Access URL: https://<any-node-ip>:<nodePort>
+# If you passed --ui-service-type LoadBalancer: the EXTERNAL-IP column shows the LB IP
+#   Access URL: https://<EXTERNAL-IP>
+```
+
+#### Get the Admin Token
+
+```bash
+# Option 1: use the bundled helper script
+./fetch_egs_slice_token.sh -k /path/to/kube_config_cluster.yml -p avesha -a -u admin
+
+# Option 2: direct kubectl retrieval
+# The project namespace is kubeslice-<project> (default project: avesha → kubeslice-avesha)
+kubectl get secret kubeslice-rbac-rw-admin -n kubeslice-avesha \
+  -o jsonpath='{.data.token}' | base64 -d
+```
+
+---
+
+## 7. Troubleshooting
+
+### 7.1 No active Kubernetes context found
+
+The installer cannot find a valid kubeconfig. Ensure `KUBECONFIG` is exported and the context is active:
+
+```bash
+export KUBECONFIG=/path/to/kube_config_cluster.yml
+kubectl config current-context
+kubectl get nodes
+```
+
+### 7.2 License file not found
+
+The installer exits with `❌ ERROR: License file not found`. Confirm the file exists and the path is correct:
+
+```bash
+ls -la egs-license.yaml
+
+# Or specify the full path explicitly:
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --license-file /full/path/to/egs-license.yaml ...
+```
+
+### 7.3 PodMonitor CRD not found
+
+**Error:** `no matches for kind "PodMonitor" in version "monitoring.coreos.com/v1"`
+
+This occurs when `--skip-prometheus` was used but Prometheus CRDs are absent. Either remove `--skip-prometheus` or manually install the CRDs:
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm install prometheus prometheus-community/kube-prometheus-stack \
+  --namespace egs-monitoring --create-namespace \
+  --kubeconfig $KUBECONFIG_PATH
+```
+
+### 7.4 UI service stuck in Pending (only if LoadBalancer was selected)
+
+This does **not** occur with the default `NodePort` service type. It happens only if you explicitly passed `--ui-service-type LoadBalancer` on a bare-metal RKE cluster with no LB provider — the `kubeslice-ui-proxy` service then stays in `<pending>` for its external IP. Re-run with the default (omit the flag) or `--ui-service-type NodePort`, or install MetalLB and re-run:
+
+```bash
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --license-file $LICENSE_FILE \
+  --kubeconfig $KUBECONFIG_PATH \
+  --cluster-name $CLUSTER_NAME \
+  --skip-postgresql --skip-prometheus --skip-gpu-operator \
+  --skip-worker \
+  --ui-service-type NodePort
+```
+
+### 7.5 Controller requires PostgreSQL
+
+**Error:** `❌ ERROR: Controller installation requires PostgreSQL to be installed.`
+
+If you used `--skip-postgresql`, confirm that a Helm release named `postgresql` or `kt-postgresql` exists:
+
+```bash
+helm list -A | grep -i postgresql
+```
+
+### 7.6 Node labeling blocked by admission policy (worker installs only)
+
+> Applies when you later install/register a **worker** cluster — gateway labeling is not performed during this controller-only install.
+
+If the worker cluster has OPA/Gatekeeper or PSP policies that block node label mutations, manually apply the gateway label before installing the worker:
+
+```bash
+kubectl label node <node-name> kubeslice.io/node-type=gateway --overwrite
+```
+
+---
+
+## 8. Next Steps
+
+After the standalone Controller is running, you can register remote worker clusters. For the full worker installation guide (separate cluster and same-cluster cases), see [EGS Worker — Installation Guide for RKE Clusters](EGS-RKE-Worker-Install-Guide.md).
+
+Each worker cluster registration requires:
+
+- A separate kubeconfig for the worker cluster
+- The Controller kubeconfig (already used above)
+- A unique name for the worker cluster
+
+Register and install a worker cluster with a single command:
+
+```bash
+export CONTROLLER_KUBECONFIG="/path/to/kube_config_cluster.yml"
+export WORKER_KUBECONFIG="/path/to/worker-kubeconfig.yaml"
+export CLUSTER_NAME="rke-worker-1"
+export PROJECT_NAME="avesha"
+
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --register-worker \
+  --controller-kubeconfig $CONTROLLER_KUBECONFIG \
+  --worker-kubeconfig $WORKER_KUBECONFIG \
+  --register-cluster-name $CLUSTER_NAME \
+  --register-project-name $PROJECT_NAME
+```
+
+### Related Documentation
+
+- [EGS License Setup](../docs/EGS-License-Setup.md)
+- [Quick Install Guide](../docs/Quick-Install-README.md)
+- [Full Installation Guide](../README.md)
+- [Configuration Reference](../docs/Configuration-README.md)
+- [Preflight Check](../docs/EGS-Preflight-Check-README.md)
+- [EGS User Guide](https://docs.avesha.io/documentation/enterprise-egs)
+
+---
+
+*Confidential — Internal Use Only*

--- a/poc/EGS-RKE-Worker-Install-Guide.md
+++ b/poc/EGS-RKE-Worker-Install-Guide.md
@@ -1,0 +1,417 @@
+# EGS Worker — Installation Guide for RKE Clusters
+
+> **Based on:** EGS Quick Install v1.0 | Rancher Kubernetes Engine (RKE)
+> **Scope:** Register and install the **EGS Worker** against an **existing EGS Controller** — on a **separate worker cluster** or on the **same cluster** as the Controller
+> **Prerequisite guide:** [EGS Standalone Controller — Installation Guide for RKE Clusters](EGS-RKE-Controller-Install-Guide.md)
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Prerequisites](#2-prerequisites)
+3. [Worker Installation](#3-worker-installation)
+4. [Network Requirements (Separate Worker Cluster)](#4-network-requirements-separate-worker-cluster)
+5. [What the Installer Does](#5-what-the-installer-does)
+6. [Post-Install Verification](#6-post-install-verification)
+7. [Troubleshooting](#7-troubleshooting)
+8. [Next Steps](#8-next-steps)
+
+---
+
+## 1. Overview
+
+This guide covers registering and installing the **EGS Worker** against an **EGS Controller that is already running**. It applies to two cases:
+
+| Case | Worker location | When to use |
+|------|-----------------|-------------|
+| **A — Separate worker cluster** | A different RKE cluster from the Controller | Standard multi-cluster setup: a dedicated control-plane cluster manages one or more remote worker clusters |
+| **B — Same cluster as the Controller** | The same RKE cluster that runs the Controller | Single-cluster setup: the Controller and Worker are co-located |
+
+In both cases the EGS Quick Installer (`install-egs.sh`) **registers** the worker with the Controller (creates the `Cluster` custom resource) and **installs** the EGS Worker chart. **No EGS license is required** — the license is validated only when the Controller itself is installed or upgraded.
+
+If the Controller is not yet installed, complete the [Controller installation guide](EGS-RKE-Controller-Install-Guide.md) first, then return here.
+
+### What This Guide Installs (on the worker cluster)
+
+| Component | Namespace | Notes |
+|-----------|-----------|-------|
+| EGS Worker | `kubeslice-system` | Operator, slice-gateway, and `kubeslice-dns` |
+| Prometheus (worker) | `egs-monitoring` | Installed by default; supplies the `PodMonitor` CRDs the Worker needs. Skip with `--skip-worker-prometheus` if already present |
+| GPU Operator (worker) | `egs-gpu-operator` | Installed by default on GPU nodes; skip with `--skip-worker-gpu-operator` |
+| Cluster registration | `kubeslice-<project>` on the **Controller** (e.g. `kubeslice-avesha`) | `Cluster` CR created on the Controller |
+
+### What This Guide Does NOT Touch
+
+- **EGS Controller, UI, and PostgreSQL** — already installed on the Controller cluster; automatically skipped during a `--register-worker` run
+- **EGS License** — not required for worker registration or installation
+
+---
+
+## 2. Prerequisites
+
+### 2.1 Existing Controller
+
+The EGS Controller must already be installed and running. Verify on the **Controller** cluster:
+
+```bash
+# Controller and UI pods should be Running
+kubectl --kubeconfig <controller-kubeconfig> get pods -n kubeslice-controller
+
+# The project namespace should exist (default project: avesha)
+kubectl --kubeconfig <controller-kubeconfig> get ns kubeslice-avesha
+```
+
+If these are missing, install the Controller first using the [Controller installation guide](EGS-RKE-Controller-Install-Guide.md).
+
+> 🔑 **Critical for a separate worker cluster (Case A):** the Controller must advertise a **routable** Kubernetes API endpoint so the remote worker can connect back to it. This is set during the **Controller install** with `--controller-endpoint` (see [Section 4](#4-network-requirements-separate-worker-cluster)). It **cannot** be changed by the worker registration command.
+
+### 2.2 Kubeconfigs
+
+| Case | Kubeconfigs needed |
+|------|--------------------|
+| **A — Separate worker cluster** | Controller kubeconfig **and** the worker cluster kubeconfig |
+| **B — Same cluster** | A single kubeconfig (the cluster runs both Controller and Worker) |
+
+RKE generates a kubeconfig at `kube_config_cluster.yml` in the directory where `rke up` was executed. Verify connectivity to each cluster you will use:
+
+```bash
+kubectl --kubeconfig /path/to/controller/kube_config_cluster.yml get nodes
+kubectl --kubeconfig /path/to/worker/kube_config_cluster.yml get nodes
+```
+
+### 2.3 Worker Cluster Requirements
+
+- Admin-level kubeconfig for the worker cluster
+- At least one node available to receive the `kubeslice.io/node-type=gateway` label (auto-applied by the installer — see [Section 2.5](#25-gateway-node-labeling))
+- **Prometheus `PodMonitor` CRDs**: the Worker requires them. The installer installs the worker's Prometheus by default; if you already run a compatible Prometheus on the worker, you may pass `--skip-worker-prometheus`
+- **GPU Operator** (GPU clusters): for nodes with NVIDIA GPUs, the installer installs the NVIDIA GPU Operator on the worker by default so GPU workloads can be scheduled. On CPU-only worker clusters, or where the GPU Operator is already installed, pass `--skip-worker-gpu-operator` to skip it
+- **Network reachability to the Controller API** (Case A only) — see [Section 4](#4-network-requirements-separate-worker-cluster)
+
+### 2.4 Required CLI Tools
+
+Verify each tool is installed and at the required version before running the installer:
+
+| Tool | Min Version | Verify Command |
+|------|-------------|----------------|
+| `kubectl` | v1.23.6+ | `kubectl version --client` |
+| `helm` | v3.15.0+ | `helm version` |
+| `yq` | v4.44.2+ | `yq --version` |
+| `jq` | v1.6+ | `jq --version` |
+| `git` | Any recent | `git --version` |
+| `curl` | Any recent | `curl --version` |
+
+### 2.5 Gateway Node Labeling
+
+> **Note:** Because the Worker is installed, the installer's worker pre-check labels a node on the **worker cluster** with `kubeslice.io/node-type=gateway` (config key `add_node_label: true`) so the slice-gateway and `kubeslice-dns` pods can schedule. It prefers a node with an `ExternalIP`, falling back to the first available node.
+
+No manual action is required unless your cluster blocks automatic node labeling (OPA/Gatekeeper/PSP) — see [Section 7.5](#75-node-labeling-blocked-by-admission-policy). To pre-label manually:
+
+```bash
+kubectl --kubeconfig <worker-kubeconfig> \
+  label node <node-name> kubeslice.io/node-type=gateway --overwrite
+```
+
+---
+
+## 3. Worker Installation
+
+### 3.1 Case A — Add a Separate Worker Cluster (recommended)
+
+Run from anywhere that can reach **both** the Controller and the worker cluster APIs. The `--register-worker` flow registers the worker with the Controller, then installs the Worker chart on the worker cluster. Controller, UI, and PostgreSQL are automatically skipped.
+
+#### Register AND Install in One Command
+
+```bash
+# ============ CUSTOMIZE THESE VALUES ============
+export CONTROLLER_KUBECONFIG="/path/to/controller/kube_config_cluster.yml"
+export WORKER_KUBECONFIG="/path/to/worker/kube_config_cluster.yml"
+export CLUSTER_NAME="rke-worker-1"            # Unique name to register this worker as
+export PROJECT_NAME="avesha"                  # Project name (default: avesha)
+
+# ============ REGISTER + INSTALL ============
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --register-worker \
+  --controller-kubeconfig $CONTROLLER_KUBECONFIG \
+  --worker-kubeconfig $WORKER_KUBECONFIG \
+  --register-cluster-name $CLUSTER_NAME \
+  --register-project-name $PROJECT_NAME
+```
+
+This registers `rke-worker-1` on the Controller and installs the EGS Worker (namespace `kubeslice-system`) on the worker cluster, including the worker's Prometheus and GPU Operator unless skipped.
+
+#### CPU-Only Worker Cluster
+
+Add `--skip-worker-gpu-operator` on worker clusters with no NVIDIA GPUs:
+
+```bash
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --register-worker \
+  --controller-kubeconfig $CONTROLLER_KUBECONFIG \
+  --worker-kubeconfig $WORKER_KUBECONFIG \
+  --register-cluster-name $CLUSTER_NAME \
+  --register-project-name $PROJECT_NAME \
+  --skip-worker-gpu-operator
+```
+
+#### Register Only, Install Later
+
+To register the worker now and install it later (for example, when the worker cluster is provisioned separately), omit `--worker-kubeconfig`:
+
+```bash
+# Step 1 — Register only (creates the Cluster CR on the Controller)
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --register-worker \
+  --controller-kubeconfig $CONTROLLER_KUBECONFIG \
+  --register-cluster-name $CLUSTER_NAME \
+  --register-project-name $PROJECT_NAME
+```
+
+```bash
+# Step 2 — Later, register + install with the worker kubeconfig
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --register-worker \
+  --controller-kubeconfig $CONTROLLER_KUBECONFIG \
+  --worker-kubeconfig $WORKER_KUBECONFIG \
+  --register-cluster-name $CLUSTER_NAME \
+  --register-project-name $PROJECT_NAME
+```
+
+> Re-running with the **same** `--register-cluster-name` is safe: the installer preserves the existing entry and does not create a duplicate registration.
+
+### 3.2 Case B — Worker on the Same Cluster as the Controller
+
+When the worker is the **same cluster** as the Controller, you do not need a second kubeconfig or `--register-worker`. Run the installer against that single cluster and skip everything that is already installed; the installer registers the cluster and installs only the Worker.
+
+```bash
+# ============ CUSTOMIZE THESE VALUES ============
+export KUBECONFIG_PATH="/path/to/kube_config_cluster.yml"   # The Controller's own cluster
+export CLUSTER_NAME="rke-egs"                               # Name to register this worker as
+
+# ============ INSTALL ONLY THE WORKER (no license needed) ============
+curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+  --kubeconfig $KUBECONFIG_PATH \
+  --cluster-name $CLUSTER_NAME \
+  --skip-postgresql \
+  --skip-prometheus \
+  --skip-gpu-operator \
+  --skip-controller \
+  --skip-ui
+```
+
+This reuses the existing PostgreSQL, Prometheus, and Controller on the cluster. The Worker reaches the Controller API locally, so **no network configuration or `--controller-endpoint` override is needed**. The installer labels the gateway node and registers the Worker.
+
+> **GPU note:** drop `--skip-gpu-operator` if this cluster has NVIDIA GPUs and the GPU Operator is not already installed.
+
+### 3.3 Flag Reference
+
+| Flag | Effect | Applies to |
+|------|--------|-----------|
+| `--register-worker` | Register a worker with the Controller (auto-skips Controller/UI/PostgreSQL) | Case A |
+| `--controller-kubeconfig PATH` | Controller cluster kubeconfig (**required** with `--register-worker`) | Case A |
+| `--worker-kubeconfig PATH` | Worker cluster kubeconfig; if provided, the Worker is installed after registration | Case A |
+| `--register-cluster-name NAME` | Unique name to register the worker as (**required** with `--register-worker`) | Case A |
+| `--register-project-name NAME` | Project name (default: `avesha`) | Case A |
+| `--kubeconfig PATH` | Cluster kubeconfig (Controller's own cluster) | Case B |
+| `--cluster-name NAME` | Registered worker name and `Cluster` CR name | Case B |
+| `--skip-controller`, `--skip-ui`, `--skip-postgresql`, `--skip-prometheus`, `--skip-gpu-operator` | Skip components already installed | Case B |
+| `--skip-worker-prometheus` | Skip Prometheus on the worker cluster (use only if a compatible Prometheus already exists) | Case A |
+| `--skip-worker-gpu-operator` | Skip GPU Operator on the worker cluster | Case A |
+| `--telemetry-endpoint URL` | External Prometheus endpoint on the worker for controller-side metrics | Case A |
+| `--cloud-provider NAME` / `--cloud-region NAME` | Record the worker's cloud provider/region in its registration | Case A |
+
+---
+
+## 4. Network Requirements (Separate Worker Cluster)
+
+> Applies to **Case A** only. For Case B (same cluster) the Worker reaches the Controller API locally and this section does not apply.
+
+In a multi-cluster setup the worker connects **back to the Controller** to sync its `Cluster` and `WorkerSlice*` resources and to report to the EGS control plane. Three reachability paths must exist:
+
+| Path | Direction | Why it's needed |
+|------|-----------|-----------------|
+| **Worker → Controller API** | worker pods → `https://<controller-ip>:6443` | The worker operator reads/writes resources in the Controller's project namespace (`kubeslice-<project>`) |
+| **Worker `egs-agent` → Controller UI proxy** | `egs-agent` pod → `https://<controller-ip>:<ui-proxy-nodeport>` (e.g. `:32702`) | The `egs-agent` connects to the Controller's `kubeslice-ui-proxy` (its `API_GW_ENDPOINT`). The installer auto-fetches this URL — see [Section 4.2](#42-egs-agent-endpoint-auto-fetched-from-the-controller) |
+| **Controller → Worker telemetry** | Controller → worker Prometheus | Metrics / KubeTally collection (optionally set via `--telemetry-endpoint`) |
+
+### 4.1 Controller Endpoint in the Worker Onboarding Secret
+
+When the worker is registered, the Controller mints a secret whose `controllerEndpoint` is taken from the **Controller's advertised API URL**. On single-node **RKE/K3s/kubeadm**, that URL is often `https://127.0.0.1:6443`, which a **remote** worker cannot reach.
+
+> 🔑 **Set the routable endpoint during the Controller install/upgrade**, not during worker registration. The `--controller-endpoint` flag is only effective when the Controller is installed or upgraded; in `--register-worker` mode it is a **no-op**, and new worker secrets inherit the Controller's existing advertised endpoint. If the Controller currently advertises `127.0.0.1`, re-run the Controller install with:
+>
+> ```bash
+> curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
+>   --license-file egs-license.yaml \
+>   --kubeconfig <controller-kubeconfig> \
+>   --cluster-name <controller-name> \
+>   --skip-worker \
+>   --controller-endpoint https://<routable-controller-ip>:6443
+> ```
+
+### 4.2 `egs-agent` Endpoint (auto-fetched from the Controller)
+
+The worker's `egs-agent` connects to the Controller's `kubeslice-ui-proxy` service (its `API_GW_ENDPOINT`). The installer **automatically discovers** this endpoint from the Controller cluster during a `--register-worker` run and writes it into the Worker values — **no manual override is required**:
+
+- If `kubeslice-ui-proxy` is a **NodePort** (the RKE/K3s default), the installer uses `https://<controller-node-ip>:<nodeport>` (for example `https://<controller-ip>:32702`).
+- If it is a **LoadBalancer**, the installer uses the load balancer hostname/IP.
+- If it is **ClusterIP only**, the installer records the in-cluster address, which a **remote** worker cannot reach.
+
+> 🔑 **Reachability requirement (Case A):** the discovered `egs-agent` endpoint must be reachable **from the worker cluster**. On a separate worker cluster, expose the Controller's `kubeslice-ui-proxy` as a **NodePort or LoadBalancer** (NodePort is the default) and ensure L3 reachability to that port. If `kubeslice-ui-proxy` is ClusterIP-only, switch it to NodePort/LoadBalancer on the Controller before registering the worker.
+
+Verify the auto-populated endpoint after install (it must **not** be empty):
+
+```bash
+kubectl --kubeconfig <worker-kubeconfig> \
+  get secret egs-agent-access -n kubeslice-system \
+  -o jsonpath='{.data.API_GW_ENDPOINT}' | base64 -d; echo
+```
+
+### 4.3 Symptom of an Unreachable Controller Endpoint
+
+The Worker chart deploys and the `kubeslice-operator` pod may even report `Ready` (its readiness probe is a local health check), but its `manager` container logs repeat the following and reconciles never succeed:
+
+```
+failed to get server groups: Get "https://<controller-ip>:6443/api":
+dial tcp <controller-ip>:6443: connect: no route to host
+```
+
+The Worker chart installed correctly — it simply cannot reach the Controller API. Fix L3 reachability (routing / firewall / NAT) and ensure the Controller advertises a routable endpoint ([Section 4.1](#41-controller-endpoint-in-the-worker-onboarding-secret)).
+
+---
+
+## 5. What the Installer Does
+
+For a `--register-worker` run with a worker kubeconfig (Case A), these steps execute automatically in order:
+
+1. Downloads `install-egs.sh` and supporting scripts from `repo.egs.avesha.io`
+2. Clones the `egs-installation` repository internally
+3. Connects to the Controller with `--controller-kubeconfig` and **registers** the cluster (creates the `Cluster` CR in `kubeslice-<project>`)
+4. **Automatically skips** Controller, UI, and PostgreSQL (they belong to the Controller cluster)
+5. Validates worker cluster connectivity (non-fatal — see [Section 7.3](#73-worker-registered-but-not-installing))
+6. Labels a gateway node on the worker cluster with `kubeslice.io/node-type=gateway`
+7. Installs the worker's Prometheus and GPU Operator (unless `--skip-worker-prometheus` / `--skip-worker-gpu-operator`)
+8. Installs the EGS Worker in the `kubeslice-system` namespace on the worker cluster
+9. Prints completion status to the terminal
+
+> For **Case B** (same cluster), steps 3–8 run against the single cluster, reusing the existing Controller/UI/PostgreSQL and installing only the Worker.
+
+> **Note:** The installer writes these files to your working directory: `egs-installer-config.yaml`, `egs-installer.sh`, `egs-install-prerequisites.sh`, `egs-uninstall.sh`, `fetch_egs_slice_token.sh`, and a `charts/` directory. Keep them for future upgrades or uninstallation.
+
+---
+
+## 6. Post-Install Verification
+
+### 6.1 Worker Pods (on the worker cluster)
+
+```bash
+# Worker components: operator, slice-gateway, kubeslice-dns
+kubectl --kubeconfig <worker-kubeconfig> get pods -n kubeslice-system
+```
+
+All pods should reach `Running` / `Ready`. *(For Case B, use the single cluster kubeconfig.)*
+
+### 6.2 Cluster Registration (on the Controller)
+
+```bash
+# Project namespace is kubeslice-<project> (default project: avesha)
+kubectl --kubeconfig <controller-kubeconfig> \
+  get cluster.controller.kubeslice.io -n kubeslice-avesha
+```
+
+The name you registered should be listed and show the worker as registered/connected.
+
+### 6.3 Gateway Node Label (on the worker cluster)
+
+```bash
+kubectl --kubeconfig <worker-kubeconfig> get nodes -l kubeslice.io/node-type=gateway
+```
+
+At least one node should be returned.
+
+### 6.4 Operator Reconciling (Case A)
+
+Confirm the worker operator can reach the Controller API (no `no route to host`):
+
+```bash
+kubectl --kubeconfig <worker-kubeconfig> \
+  logs -n kubeslice-system deploy/kubeslice-operator -c manager --tail=50
+```
+
+---
+
+## 7. Troubleshooting
+
+### 7.1 PodMonitor CRD not found
+
+**Error:** `no matches for kind "PodMonitor" in version "monitoring.coreos.com/v1"`
+
+The Worker needs Prometheus `PodMonitor` CRDs on the worker cluster. Do **not** pass `--skip-worker-prometheus` unless a compatible Prometheus is already installed. To install Prometheus/CRDs manually on the worker:
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm install prometheus prometheus-community/kube-prometheus-stack \
+  --namespace egs-monitoring --create-namespace \
+  --kubeconfig <worker-kubeconfig>
+```
+
+### 7.2 Worker operator: "no route to host" to the Controller API
+
+The worker cannot reach the Controller's Kubernetes API. See [Section 4](#4-network-requirements-separate-worker-cluster): verify L3 reachability to `https://<controller-ip>:6443` from the worker, and ensure the Controller advertises a routable endpoint (re-run the Controller install with `--controller-endpoint <routable-url>` if it currently advertises `127.0.0.1`).
+
+### 7.3 Worker registered but not installing
+
+If you ran `--register-worker` **without** `--worker-kubeconfig`, only the `Cluster` CR was created. Install the worker by re-running with `--worker-kubeconfig` ([Section 3.1](#31-case-a--add-a-separate-worker-cluster-recommended), Step 2).
+
+> Worker connectivity during registration is **non-fatal**: if the worker is unreachable, the installer prints `⚠️ Cannot connect to worker cluster (non-fatal, continuing...)`, still creates the `Cluster` CR, and the worker install fails later if it remains unreachable.
+
+### 7.4 Cluster not appearing under registration
+
+If `kubectl get cluster.controller.kubeslice.io -n kubeslice-avesha` does not list your worker:
+
+- Confirm the project namespace matches your project (`kubeslice-<project>`; default `kubeslice-avesha`).
+- Confirm the Controller pods are `Running` in `kubeslice-controller`.
+- Re-run the registration command; it is idempotent and will not create duplicates for the same name.
+
+### 7.5 Node labeling blocked by admission policy
+
+If the worker cluster has OPA/Gatekeeper or PSP policies that block node label mutations, manually apply the gateway label before installing the worker:
+
+```bash
+kubectl --kubeconfig <worker-kubeconfig> \
+  label node <node-name> kubeslice.io/node-type=gateway --overwrite
+```
+
+### 7.6 No active Kubernetes context found
+
+Ensure the relevant kubeconfig is exported and the context is active:
+
+```bash
+export KUBECONFIG=/path/to/kube_config_cluster.yml
+kubectl config current-context
+kubectl get nodes
+```
+
+---
+
+## 8. Next Steps
+
+After the Worker is registered and running:
+
+- **Create slices & deploy workloads:** use the EGS UI or APIs to define slices and place GPU/CPU workloads on the registered worker.
+- **Add more workers:** repeat [Section 3.1](#31-case-a--add-a-separate-worker-cluster-recommended) with a new `--register-cluster-name` and the new worker's kubeconfig.
+- **Retrieve the UI/admin token** (if needed) from the Controller — see the [Controller installation guide](EGS-RKE-Controller-Install-Guide.md).
+- **Upgrades:** re-run the installer (optionally with `--local-repo <checkout>` to pin a specific release branch) to upgrade the Worker in place.
+
+### Related Documentation
+
+- [EGS Controller Installation Guide (RKE)](EGS-RKE-Controller-Install-Guide.md)
+- [Quick Install Guide](https://github.com/kubeslice-ent/egs-installation/blob/main/docs/Quick-Install-README.md)
+- [Full Installation Guide](https://github.com/kubeslice-ent/egs-installation/blob/main/README.md)
+- [Configuration Reference](https://github.com/kubeslice-ent/egs-installation/blob/main/docs/Configuration-README.md)
+- [Preflight Check](https://github.com/kubeslice-ent/egs-installation/blob/main/docs/EGS-Preflight-Check-README.md)
+- [EGS User Guide](https://docs.avesha.io/documentation/enterprise-egs)
+
+---
+
+*Confidential — Internal Use Only*


### PR DESCRIPTION
## Summary
Add two customer-facing installation guides under `poc/`:

- **`poc/EGS-RKE-Controller-Install-Guide.md`** — standalone EGS Controller install on RKE clusters: prerequisites, license setup, UI access, `--controller-endpoint`, and post-install verification.
- **`poc/EGS-RKE-Worker-Install-Guide.md`** — register and install the EGS Worker against an existing Controller, covering both a **separate worker cluster** (Case A) and a **worker co-located on the Controller cluster** (Case B), plus multi-cluster network requirements and verification.

The two guides cross-reference each other and the existing `docs/` and `README.md` via repo-relative links.

## Notes
- Both guides were validated against the installer source and exercised live on RKE/K3s clusters (controller install, worker registration + install, gateway labeling, and `--controller-endpoint` behavior).
- Docs-only change; no installer code is modified in this PR.

## Test plan
- [x] All internal relative links resolve (`../docs/*`, `../README.md`, same-folder cross-links).
- [x] Guides render correctly as Markdown.
