### PR TITLE
fix: add cleanupState/cleanupDeadline to ClusterGPUAllocation CRD schema

### DIFF
--- a/charts/kubeslice-controller-egs/templates/crd.clustergpuallocations.inventory.kubeslice.io.yaml
+++ b/charts/kubeslice-controller-egs/templates/crd.clustergpuallocations.inventory.kubeslice.io.yaml
@@ -93,6 +93,19 @@ spec:
                           allocationTimestamp:
                             format: date-time
                             type: string
+                          cleanupDeadline:
+                            description: CleanupDeadline is the timestamp after which
+                              a Cleaning slot is auto-released.
+                            format: date-time
+                            type: string
+                          cleanupState:
+                            description: CleanupState tracks the GPU slot cleanup
+                              lifecycle. Empty means Active.
+                            enum:
+                            - Active
+                            - Cleaning
+                            - Failed
+                            type: string
                           gprName:
                             type: string
                           profileName:


### PR DESCRIPTION
## Summary
- This chart's CRD template for ClusterGPUAllocation never received the cleanupState/cleanupDeadline fields added to inventory-manager's generated CRD schema, and has no x-kubernetes-preserve-unknown-fields — meaning the K8s apiserver silently pruned these fields on every write for real installs (this is the CRD copy egs-installer.sh actually deploys).
- Adds the missing schema block, verified byte-identical to inventory-manager's own generated CRD.

## Test plan
- [ ] Run egs-installer.sh against a test cluster; verify cleanupState/cleanupDeadline persist on ClusterGPUAllocation status writes