### PR TITLE
Fix phantom workers and null cluster_registration in register-worker/skip-worker flows

### DIFF
--- a/egs-installer.sh
+++ b/egs-installer.sh
@@ -1135,6 +1135,14 @@ parse_yaml() {
     KUBESLICE_CLUSTER_REGISTRATIONS=()
     for ((i = 0; i < CLUSTER_REGISTRATION_COUNT; i++)); do
         CLUSTER_NAME=$(yq e ".cluster_registration[$i].cluster_name" "$yaml_file")
+        # Skip malformed/sparse cluster_registration entries that have no cluster_name.
+        # Such entries can be produced by legacy index-based writes (e.g. a telemetry-only
+        # entry). Registering them would create an invalid Cluster with metadata.name=null
+        # and fail with "resource name may not be empty".
+        if [ -z "$CLUSTER_NAME" ] || [ "$CLUSTER_NAME" = "null" ]; then
+            echo "⚠️  Skipping cluster_registration[$i]: missing cluster_name (malformed/sparse entry)"
+            continue
+        fi
         PROJECT_NAME=$(yq e ".cluster_registration[$i].project_name" "$yaml_file")
         TELEMETRY_ENABLED=$(yq e ".cluster_registration[$i].telemetry.enabled" "$yaml_file")
         TELEMETRY_ENDPOINT=$(yq e ".cluster_registration[$i].telemetry.endpoint" "$yaml_file")
@@ -2271,13 +2279,41 @@ prepare_worker_values_file() {
         echo "Worker data testing:"
         echo "$worker" | yq e '.' -
 
-        reg_cluster=$(yq e ".cluster_registration[$worker_index]" "$EGS_INPUT_YAML")
-        echo "cluster registration data ..."
-        echo "$reg_cluster" | yq e '.' -
+        # Resolve THIS worker's cluster_registration entry by NAME rather than by array
+        # position. kubeslice_worker_egs[] and cluster_registration[] are independent lists
+        # whose indices need not align (e.g. when preserved/imported workers have no
+        # registration entry). A blind positional read/write here previously (a) read the
+        # wrong cluster's telemetry and (b) created a brand-new sparse cluster_registration
+        # entry with only telemetry.endpoint (cluster_name=null) whenever worker_index
+        # exceeded the number of registrations - producing a "null" Cluster that fails the
+        # install. Match by name so we only ever touch an existing, correct entry.
+        reg_index=$(yq e ".cluster_registration | to_entries | map(select(.value.cluster_name == \"${worker_name}\")) | .[0].key" "$EGS_INPUT_YAML")
+        if [ -z "$reg_index" ] || [ "$reg_index" = "null" ]; then
+            # No registration entry matches this worker by name. Fall back to the positional
+            # entry ONLY if it exists AND already carries a non-null cluster_name; otherwise
+            # treat this worker as having no registration (never fabricate one).
+            positional_name=$(yq e ".cluster_registration[$worker_index].cluster_name" "$EGS_INPUT_YAML" 2>/dev/null)
+            if [ -n "$positional_name" ] && [ "$positional_name" != "null" ]; then
+                reg_index="$worker_index"
+            else
+                reg_index=""
+            fi
+        fi
+
         echo "installation path.."
         echo $INSTALLATION_FILES_PATH
-        cluster_name=$(yq e ".cluster_registration[$worker_index].cluster_name" "$EGS_INPUT_YAML")
-        project_name=$(yq e ".cluster_registration[$worker_index].project_name" "$EGS_INPUT_YAML")
+        if [ -n "$reg_index" ]; then
+            reg_cluster=$(yq e ".cluster_registration[$reg_index]" "$EGS_INPUT_YAML")
+            echo "cluster registration data (matched index $reg_index) ..."
+            echo "$reg_cluster" | yq e '.' -
+            cluster_name=$(yq e ".cluster_registration[$reg_index].cluster_name" "$EGS_INPUT_YAML")
+            project_name=$(yq e ".cluster_registration[$reg_index].project_name" "$EGS_INPUT_YAML")
+        else
+            echo "⚠️  No cluster_registration entry matches worker '${worker_name}' - telemetry/registration updates will be skipped for it."
+            reg_cluster=""
+            cluster_name=""
+            project_name=""
+        fi
 
 
 
@@ -2382,9 +2418,17 @@ prepare_worker_values_file() {
                 yq eval ".kubeslice_worker_egs[$worker_index].inline_values.egs.prometheusEndpoint = \"${prometheus_url}\" | del(.null)" --inplace "${EGS_INPUT_YAML}"
                 echo "Updated Prometheus endpoint for worker ${worker_name}: ${prometheus_url}"
 
-                yq eval ".cluster_registration[$worker_index].telemetry.endpoint = \"${prometheus_url}\"" --inplace "${EGS_INPUT_YAML}"
-                echo "Updated Prometheus endpoint for cluster  ${cluster_name}: ${prometheus_url}"
-                sed -i "s|endpoint: .*|endpoint: ${prometheus_url}|" "$INSTALLATION_FILES_PATH/${cluster_name}_cluster.yaml"
+                # Only update telemetry on an EXISTING, name-matched registration entry.
+                # Never write by raw worker_index (that would fabricate a null-named entry).
+                if [ -n "$reg_index" ] && [ -n "$cluster_name" ] && [ "$cluster_name" != "null" ]; then
+                    yq eval ".cluster_registration[$reg_index].telemetry.endpoint = \"${prometheus_url}\"" --inplace "${EGS_INPUT_YAML}"
+                    echo "Updated Prometheus endpoint for cluster  ${cluster_name}: ${prometheus_url}"
+                    if [ -f "$INSTALLATION_FILES_PATH/${cluster_name}_cluster.yaml" ]; then
+                        sed -i "s|endpoint: .*|endpoint: ${prometheus_url}|" "$INSTALLATION_FILES_PATH/${cluster_name}_cluster.yaml"
+                    fi
+                else
+                    echo "⏩ Skipping cluster telemetry endpoint update for worker '${worker_name}' (no matching cluster_registration entry)."
+                fi
 
                 echo "Waiting for Grafana service to get an IP or port for worker..."
                 external_ip=""

--- a/install-egs.sh
+++ b/install-egs.sh
@@ -1043,6 +1043,14 @@ if [ "$REGISTER_WORKER" = "true" ]; then
                     print_info "Skipping existing cluster '$CLUSTER' (will be added as new worker)"
                     continue
                 fi
+
+                # Skip the shipped template placeholder "worker-1". It is the sample name in
+                # the repo config, never a real customer cluster, and importing it seeds a
+                # phantom worker (and a spurious Cluster CR) into the generated config.
+                if [ "$CLUSTER" = "worker-1" ] && [ "$REGISTER_CLUSTER_NAME" != "worker-1" ]; then
+                    print_info "Skipping template placeholder cluster 'worker-1' (not importing as a worker)"
+                    continue
+                fi
                 
                 # Load template for each existing cluster
                 if [ -f "$TEMP_WORKER_TEMPLATE" ]; then
@@ -1625,6 +1633,35 @@ else
             print_info "Added cluster_registration entry for worker: $REG_NAME"
         fi
     done
+fi
+
+# --- Bug fix: remove the shipped template placeholder "worker-1" (register-worker mode) ---
+# The repo config ships a sample worker/registration named "worker-1". In register-worker
+# mode this placeholder must never leak into a customer's generated config as a phantom
+# worker or a spurious Cluster CR. Drop it from BOTH lists unless the user is explicitly
+# registering a cluster literally named "worker-1".
+if [ "$REGISTER_WORKER" = "true" ] && [ "$REGISTER_CLUSTER_NAME" != "worker-1" ]; then
+    PLACEHOLDER_WORKERS=$(yq eval '[.kubeslice_worker_egs[] | select(.name == "worker-1")] | length' egs-installer-config.yaml 2>/dev/null || echo "0")
+    if [ "$PLACEHOLDER_WORKERS" -gt 0 ]; then
+        yq eval 'del(.kubeslice_worker_egs[] | select(.name == "worker-1"))' -i egs-installer-config.yaml
+        print_info "Removed $PLACEHOLDER_WORKERS placeholder worker entry(ies) named 'worker-1'"
+    fi
+    PLACEHOLDER_REGS=$(yq eval '[.cluster_registration[] | select(.cluster_name == "worker-1")] | length' egs-installer-config.yaml 2>/dev/null || echo "0")
+    if [ "$PLACEHOLDER_REGS" -gt 0 ]; then
+        yq eval 'del(.cluster_registration[] | select(.cluster_name == "worker-1"))' -i egs-installer-config.yaml
+        print_info "Removed $PLACEHOLDER_REGS placeholder cluster_registration entry(ies) named 'worker-1'"
+    fi
+fi
+
+# --- Bug fix: controller-only install (--skip-worker, single cluster) must not register the
+# controller's own cluster name as a worker cluster. Registering it creates a spurious
+# Cluster CR that later leaks into other installs as a phantom worker (and clutters
+# installation-files). Only applies when no worker kubeconfig was provided and we are not in
+# register-worker mode (where registration of the new worker is intentional).
+if [ "$SKIP_WORKER" = "true" ] && [ "$REGISTER_WORKER" != "true" ] && [ ${#WORKER_KUBECONFIGS[@]} -eq 0 ]; then
+    yq eval '.enable_cluster_registration = false' -i egs-installer-config.yaml
+    yq eval 'del(.cluster_registration[])' -i egs-installer-config.yaml
+    print_info "Controller-only install (--skip-worker): disabled cluster registration (no worker cluster to register)"
 fi
 
 # Update image registry

--- a/install-egs.sh
+++ b/install-egs.sh
@@ -1014,77 +1014,25 @@ if [ "$REGISTER_WORKER" = "true" ]; then
             WORKERS_PRESERVED_FROM_CONTROLLER="false"
         fi
     else
-        # No local config - check controller cluster for existing workers
-        print_info "No local config found - checking controller cluster for existing workers..."
-        CONTROLLER_CMD="kubectl --kubeconfig $CONTROLLER_KUBECONFIG"
-        if [ -n "$CONTROLLER_CONTEXT" ]; then
-            CONTROLLER_CMD="$CONTROLLER_CMD --context $CONTROLLER_CONTEXT"
-        fi
-        
-        # Check for cluster CRDs in the project namespace
-        PROJECT_NAMESPACE="kubeslice-$REGISTER_PROJECT_NAME"
-        EXISTING_CLUSTERS=$($CONTROLLER_CMD get cluster.controller.kubeslice.io -n "$PROJECT_NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
-        
-        if [ -n "$EXISTING_CLUSTERS" ]; then
-            print_info "Found existing worker clusters in controller: $EXISTING_CLUSTERS"
-            print_info "These workers will be preserved in the config"
-            
-            # Copy repo config as base
-            install_repo_config
-            
-            # Delete the default worker entry
-            yq eval 'del(.kubeslice_worker_egs[])' -i "$ORIGINAL_DIR/egs-installer-config.yaml"
-            
-            # Add existing clusters as worker entries (using template structure)
-            CLUSTER_INDEX=0
-            for CLUSTER in $EXISTING_CLUSTERS; do
-                # Skip if this is the cluster we're currently registering (avoid duplicate)
-                if [ "$CLUSTER" = "$REGISTER_CLUSTER_NAME" ]; then
-                    print_info "Skipping existing cluster '$CLUSTER' (will be added as new worker)"
-                    continue
-                fi
-
-                # Skip the shipped template placeholder "worker-1". It is the sample name in
-                # the repo config, never a real customer cluster, and importing it seeds a
-                # phantom worker (and a spurious Cluster CR) into the generated config.
-                if [ "$CLUSTER" = "worker-1" ] && [ "$REGISTER_CLUSTER_NAME" != "worker-1" ]; then
-                    print_info "Skipping template placeholder cluster 'worker-1' (not importing as a worker)"
-                    continue
-                fi
-                
-                # Load template for each existing cluster
-                if [ -f "$TEMP_WORKER_TEMPLATE" ]; then
-                    print_info "Adding preserved worker: $CLUSTER at index $CLUSTER_INDEX"
-                    # Load the template structure
-                    yq eval ".kubeslice_worker_egs[$CLUSTER_INDEX] = load(\"$TEMP_WORKER_TEMPLATE\")" -i "$ORIGINAL_DIR/egs-installer-config.yaml"
-                    
-                    # Now update ALL specific fields for preserved workers (AFTER template load)
-                    # This ensures our values override any template defaults
-                    yq eval ".kubeslice_worker_egs[$CLUSTER_INDEX].name = \"$CLUSTER\" | .kubeslice_worker_egs[$CLUSTER_INDEX].name style=\"double\"" -i "$ORIGINAL_DIR/egs-installer-config.yaml"
-                    yq eval ".kubeslice_worker_egs[$CLUSTER_INDEX].use_global_kubeconfig = true" -i "$ORIGINAL_DIR/egs-installer-config.yaml"
-                    yq eval ".kubeslice_worker_egs[$CLUSTER_INDEX].kubeconfig = \"\" | .kubeslice_worker_egs[$CLUSTER_INDEX].kubeconfig style=\"double\"" -i "$ORIGINAL_DIR/egs-installer-config.yaml"
-                    yq eval ".kubeslice_worker_egs[$CLUSTER_INDEX].kubecontext = \"\" | .kubeslice_worker_egs[$CLUSTER_INDEX].kubecontext style=\"double\"" -i "$ORIGINAL_DIR/egs-installer-config.yaml"
-                    yq eval ".kubeslice_worker_egs[$CLUSTER_INDEX].skip_installation = true" -i "$ORIGINAL_DIR/egs-installer-config.yaml"
-                    
-                    # Double-check it was set correctly
-                    VERIFY_SKIP=$(yq eval ".kubeslice_worker_egs[$CLUSTER_INDEX].skip_installation" "$ORIGINAL_DIR/egs-installer-config.yaml" 2>/dev/null)
-                    VERIFY_USE_GLOBAL=$(yq eval ".kubeslice_worker_egs[$CLUSTER_INDEX].use_global_kubeconfig" "$ORIGINAL_DIR/egs-installer-config.yaml" 2>/dev/null)
-                    if [ "$VERIFY_SKIP" = "true" ] && [ "$VERIFY_USE_GLOBAL" = "true" ]; then
-                        print_info "✅ Preserved worker: $CLUSTER (skip_installation=true, use_global_kubeconfig=true, will not be reinstalled)"
-                    else
-                        print_warning "⚠️  Failed to set skip_installation for $CLUSTER (skip=$VERIFY_SKIP, use_global=$VERIFY_USE_GLOBAL)"
-                    fi
-                    CLUSTER_INDEX=$((CLUSTER_INDEX + 1))
-                fi
-            done
-            EXISTING_WORKERS=$CLUSTER_INDEX
-            print_info "Added $EXISTING_WORKERS preserved worker(s) from controller cluster"
-        else
-            print_info "No existing workers found in controller cluster"
-            # Copy repo config as is
-            install_repo_config
-            EXISTING_WORKERS=0
-        fi
+        # No local config found. Generate a clean, self-contained config for JUST the
+        # worker being registered.
+        #
+        # We deliberately do NOT import every cluster already registered on the controller
+        # as a worker entry. A targeted `--register-worker --register-cluster-name X` should
+        # only produce/act on the single cluster X the user named. Auto-importing all
+        # controller-registered clusters previously:
+        #   (a) listed unrelated clusters (e.g. other workers, even the controller) under
+        #       kubeslice_worker_egs in the new worker's config,
+        #   (b) generated their YAML under installation-files, and
+        #   (c) misaligned kubeslice_worker_egs[] with cluster_registration[], which
+        #       fabricated a null-named Cluster and made the 3rd/4th registration fatal.
+        # The controller already tracks every registered cluster independently, so nothing
+        # is lost by omitting them here. (Multi-worker preservation still works when you
+        # keep and re-use a local egs-installer-config.yaml — handled in the branch above.)
+        print_info "No local config found - generating a clean config for worker '$REGISTER_CLUSTER_NAME' only (existing controller clusters are left untouched)."
+        install_repo_config
+        EXISTING_WORKERS=0
+        WORKERS_PRESERVED_FROM_CONTROLLER="false"
     fi
 else
     # Normal mode: always copy from repo (ONLY if not in register-worker mode with existing workers)


### PR DESCRIPTION
## Summary
Fixes four related config-generation bugs in the Quick Installer that could corrupt `egs-installer-config.yaml` and fail the install:

- **egs-installer.sh (critical):** `prepare_worker_values_file` wrote telemetry to `cluster_registration[worker_index]` positionally. When `kubeslice_worker_egs[]` and `cluster_registration[]` were misaligned this fabricated a sparse, name-less entry → a `null` Cluster that fails with `resource name may not be empty`. The entry is now resolved by matching `cluster_name` to the worker name, and the write only touches an existing, name-matched entry.
- **egs-installer.sh:** `parse_yaml` now skips malformed/sparse `cluster_registration` entries (missing `cluster_name`) so they are never registered.
- **install-egs.sh:** never imports the shipped template placeholder `worker-1` from the controller as a worker, and purges any leftover `worker-1` worker/registration entry in `--register-worker` mode.
- **install-egs.sh:** a controller-only install (`--skip-worker`, single cluster) no longer self-registers the controller's own cluster name as a worker cluster (disables `cluster_registration`), preventing spurious Cluster CRs from leaking into other installs as phantom workers.

## Test plan
- [x] `bash -n install-egs.sh` and `bash -n egs-installer.sh`
- [x] Live on RKE/K3s controller — controller-only `--skip-worker`: `enable_cluster_registration=false`, 0 registrations, no `worker-1`
- [x] Live `--register-worker` (`--generate-config`): only intended worker, no `worker-1`, 0 null entries
- [x] Live old-vs-new telemetry-write: old path creates a `null` entry, new path creates 0