### PR TITLE
fix(installer): skip values-file prep for skip_installation=true workers

### DIFF
--- a/egs-installer.sh
+++ b/egs-installer.sh
@@ -2244,6 +2244,22 @@ prepare_worker_values_file() {
         worker=$(yq e ".kubeslice_worker_egs[$worker_index]" "$EGS_INPUT_YAML")
         worker_name=$(echo "$worker" | yq e '.name' -)
         skip_installation=$(echo "$worker" | yq e '.skip_installation' -)
+
+        # ── skip_installation guard ─────────────────────────────────────────────
+        # Workers flagged skip_installation=true are NOT install targets on this run
+        # (e.g. preserved / imported / phantom entries carried in the config). They
+        # have no "kubeslice-rbac-worker-<name>" secret on the controller, so
+        # continuing here would make this function run
+        #   kubectl get secret kubeslice-rbac-worker-<name> ...
+        # which returns NotFound and aborts the ENTIRE run before any real worker
+        # chart is installed. The install loop already honours skip_installation via
+        # install_or_upgrade_helm_chart(); mirror that here and skip values-file
+        # preparation for these workers so real workers install unaffected.
+        if [ "$skip_installation" = "true" ]; then
+            echo "⏩ Skipping worker values-file preparation for '$worker_name' (skip_installation=true)."
+            continue
+        fi
+
         use_global_kubeconfig=$(echo "$worker" | yq e '.use_global_kubeconfig' -)
         namespace=$(echo "$worker" | yq e '.namespace' -)
         release_name=$(echo "$worker" | yq e '.release' -)


### PR DESCRIPTION
## Summary
- `prepare_worker_values_file()` fetched `kubeslice-rbac-worker-<name>` for **every** `kubeslice_worker_egs[]` entry, including workers with `skip_installation=true`.
- Phantom/preserved workers (e.g. `orchehost`) have no such secret → `kubectl get secret` returns `NotFound` and aborts the entire run before real workers install (hit on Telenor Z4).
- Add a `continue` guard at the top of that loop when `skip_installation=true`, matching the install loop's existing short-circuit in `install_or_upgrade_helm_chart()`.

## Test plan
- [ ] Merge this PR to `main`
- [ ] Sync the same `egs-installer.sh` change to `gh-pages` (curl entrypoint)
- [ ] On Z4: re-run worker install via curl from repo.egs.avesha.io
- [ ] Confirm log shows Skipping worker values-file preparation for skipped workers
- [ ] Confirm Z4 worker chart installs; kubeslice-system / networkPresent healthy