### PR TITLE
Sync install-egs.sh from main: install Envoy Gateway on each worker

### DIFF
--- a/docs/Quick-Install-README.md
+++ b/docs/Quick-Install-README.md
@@ -661,6 +661,7 @@ curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
 |--------|-------------|---------|
 | `--skip-controller-prometheus` | Skip Prometheus on controller cluster | Install |
 | `--skip-controller-gpu-operator` | Skip GPU Operator on controller cluster | Install |
+| `--skip-controller-envoy` | Skip Envoy Gateway on controller cluster | Install |
 
 **Worker Cluster(s):**
 
@@ -668,6 +669,14 @@ curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
 |--------|-------------|---------|
 | `--skip-worker-prometheus` | Skip Prometheus on worker cluster(s) | Install |
 | `--skip-worker-gpu-operator` | Skip GPU Operator on worker cluster(s) | Install |
+| `--skip-worker-envoy` | Skip Envoy Gateway on worker cluster(s) | Install |
+
+> 🛡️ **Envoy Gateway is installed on every worker automatically.** The kubeslice
+> worker-operator depends on the `EnvoyProxy` CRD, so in multi-cluster and
+> `--register-worker` modes the installer now deploys Envoy Gateway on **each**
+> worker cluster (using that worker's kubeconfig) by default. This prevents the
+> worker-operator from crash-looping on a missing CRD. No extra flag is needed —
+> use `--skip-worker-envoy` only if you intentionally want to opt out.
 
 **Important**: 
 - `--skip-postgresql` works the same in both modes (PostgreSQL is only on controller)
@@ -1073,11 +1082,14 @@ In multi-cluster mode, prerequisites are installed on EACH cluster:
 **Worker Cluster(s):**
 1. **📊 Prometheus Stack** (Namespace: `egs-monitoring`) - *Can be skipped with `--skip-worker-prometheus`*
 2. **🎮 GPU Operator** (Namespace: `egs-gpu-operator`) - *Can be skipped with `--skip-worker-gpu-operator`*
-3. **📋 GPU Operator Quota** (Namespace: `egs-gpu-operator`) - *ResourceQuota for GPU pods*
-4. **🖥️ NVIDIA Driver Installer** (Namespace: `kube-system`) - *DaemonSet for GPU drivers*
-5. **⚙️ EGS Worker** (Namespace: `kubeslice-system`)
+3. **🛡️ Envoy Gateway** (Namespace: `envoy-gateway-system`) - *Required by the worker-operator (EnvoyProxy CRD); can be skipped with `--skip-worker-envoy`*
+4. **📋 GPU Operator Quota** (Namespace: `egs-gpu-operator`) - *ResourceQuota for GPU pods*
+5. **🖥️ NVIDIA Driver Installer** (Namespace: `kube-system`) - *DaemonSet for GPU drivers*
+6. **⚙️ EGS Worker** (Namespace: `kubeslice-system`)
 
 **Note**: The worker requires Prometheus CRDs (PodMonitor) to be installed. If you skip Prometheus on the worker cluster, you may encounter errors like `no matches for kind "PodMonitor"`.
+
+**Note**: Envoy Gateway is installed on each worker automatically (using the worker's kubeconfig) because the kubeslice worker-operator consumes the `EnvoyProxy` CRD. If you skip it with `--skip-worker-envoy`, the worker-operator will crash-loop on a missing CRD until Envoy Gateway is present.
 
 ### Service Types
 
@@ -1171,12 +1183,16 @@ These flags provide fine-grained control over prerequisites in multi-cluster mod
 **Controller Cluster Prerequisites:**
 - `--skip-controller-prometheus`: Skip Prometheus on controller cluster only
 - `--skip-controller-gpu-operator`: Skip GPU Operator on controller cluster only
+- `--skip-controller-envoy`: Skip Envoy Gateway on controller cluster only
 
 **Worker Cluster Prerequisites:**
 - `--skip-worker-prometheus`: Skip Prometheus on ALL worker clusters
 - `--skip-worker-gpu-operator`: Skip GPU Operator on ALL worker clusters
+- `--skip-worker-envoy`: Skip Envoy Gateway on ALL worker clusters ⚠️ *not recommended — the worker-operator requires the `EnvoyProxy` CRD and will crash-loop without it*
 
 **Note:** For PostgreSQL, use `--skip-postgresql` (same flag for both modes since PostgreSQL is only on controller)
+
+**Note:** Envoy Gateway is **installed by default on every worker** (and on the controller). This is why the example commands above do **not** pass `--skip-worker-envoy` — you only add it if you intentionally want to opt out. Do not add it to a normal install.
 
 **How Skip Flags Work in Multi-Cluster Mode:**
 
@@ -1188,6 +1204,9 @@ These flags provide fine-grained control over prerequisites in multi-cluster mod
 | `--skip-controller-prometheus --skip-worker-prometheus` | ❌ Prometheus Skipped | ❌ Prometheus Skipped |
 | `--skip-controller-gpu-operator` | ❌ GPU Op Skipped | ✅ GPU Op Installed |
 | `--skip-worker-gpu-operator` | ✅ GPU Op Installed | ❌ GPU Op Skipped |
+| `--skip-controller-envoy` | ❌ Envoy Skipped | ✅ Envoy Installed |
+| `--skip-worker-envoy` | ✅ Envoy Installed | ❌ Envoy Skipped (⚠️ worker-operator will crash-loop) |
+| *(no envoy flag — default)* | ✅ Envoy Installed | ✅ Envoy Installed |
 
 **Rules:**
 1. `--skip-postgresql` → Only affects controller (PostgreSQL is never on workers)
@@ -1466,8 +1485,9 @@ export PROJECT_NAME="avesha"                                        # Project na
 # The script will:
 # 1. Register worker-2 with the controller
 # 2. Automatically install the worker on worker-2 cluster
-# 3. Preserve existing workers (skip_installation=true)
-# 4. Set new worker: skip_installation=false (will install)
+# 3. Automatically install Envoy Gateway on worker-2 (required by the worker-operator)
+# 4. Preserve existing workers (skip_installation=true)
+# 5. Set new worker: skip_installation=false (will install)
 curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
   --register-worker \
   --controller-kubeconfig $CONTROLLER_KUBECONFIG \
@@ -1475,6 +1495,12 @@ curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash -s -- \
   --register-cluster-name $CLUSTER_NAME \
   --register-project-name $PROJECT_NAME
 ```
+
+> 🛡️ **Envoy Gateway is handled for you.** The command above installs Envoy Gateway
+> on the worker identified by `--worker-kubeconfig` automatically, so the
+> worker-operator finds the `EnvoyProxy` CRD locally and does not crash-loop. You do
+> **not** need to hand-edit `egs-installer-config.yaml` or pass `--preserve-config`
+> for this. Add `--skip-worker-envoy` only if you deliberately want to skip it.
 
 **Option 2: Register Only (Without Installation)**
 
@@ -1848,7 +1874,7 @@ curl -fsSL https://repo.egs.avesha.io/install-egs.sh | bash
 ## 📚 Related Documentation
 
 - 📋 [EGS License Setup](EGS-License-Setup.html) - How to obtain and configure your license
-- 🛠️ [Full Installation Guide](../README.md#getting-started) - For multi-cluster and advanced setups
+- 🛠️ [Full Installation Guide](../README.html#getting-started) - For multi-cluster and advanced setups
 - 📊 [Configuration Documentation](Configuration-README.html) - Detailed configuration options
 - ✅ [Preflight Check](EGS-Preflight-Check-README.html) - Validate your environment before installation
 - 🌐 [EGS User Guide](https://docs.avesha.io/documentation/enterprise-egs) - Complete product documentation

--- a/install-egs.sh
+++ b/install-egs.sh
@@ -45,6 +45,13 @@ SKIP_CONTROLLER_GPU_OPERATOR="false"
 SKIP_WORKER_PROMETHEUS="false"
 SKIP_WORKER_GPU_OPERATOR="false"
 
+# Envoy Gateway is required by the kubeslice worker-operator (it consumes the
+# EnvoyProxy CRD). It is therefore installed on EACH worker cluster by default in
+# multi-cluster / --register-worker mode so onboarding does not crash-loop.
+# Use --skip-worker-envoy / --skip-controller-envoy to opt out.
+SKIP_WORKER_ENVOY="false"
+SKIP_CONTROLLER_ENVOY="false"
+
 # Worker registration mode
 REGISTER_WORKER="false"
 CONTROLLER_KUBECONFIG=""
@@ -414,10 +421,14 @@ Multi-Cluster Mode Skip Flags (use these when installing on MULTIPLE clusters):
   Controller Cluster:
     --skip-controller-prometheus    Skip Prometheus on controller cluster
     --skip-controller-gpu-operator  Skip GPU Operator on controller cluster
+    --skip-controller-envoy         Skip Envoy Gateway on controller cluster
   
   Worker Cluster(s):
     --skip-worker-prometheus        Skip Prometheus on worker cluster(s)
     --skip-worker-gpu-operator      Skip GPU Operator on worker cluster(s)
+    --skip-worker-envoy             Skip Envoy Gateway on worker cluster(s)
+                                    (Envoy is installed on each worker by default;
+                                     it is required by the worker-operator)
   
   Note: In multi-cluster mode, use --skip-controller-* and --skip-worker-* flags
         instead of --skip-prometheus and --skip-gpu-operator
@@ -604,6 +615,10 @@ while [[ $# -gt 0 ]]; do
             SKIP_CONTROLLER_GPU_OPERATOR="true"
             shift
             ;;
+        --skip-controller-envoy)
+            SKIP_CONTROLLER_ENVOY="true"
+            shift
+            ;;
         # Multi-cluster specific skip flags (worker clusters)
         --skip-worker-prometheus)
             SKIP_WORKER_PROMETHEUS="true"
@@ -611,6 +626,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-worker-gpu-operator)
             SKIP_WORKER_GPU_OPERATOR="true"
+            shift
+            ;;
+        --skip-worker-envoy)
+            SKIP_WORKER_ENVOY="true"
             shift
             ;;
         --register-worker)
@@ -1700,9 +1719,19 @@ if [ "$MULTI_CLUSTER" = "true" ] && [ ${#WORKER_KUBECONFIG_RELATIVES[@]} -gt 0 ]
         CONTROLLER_SKIP_GPU_OPERATOR="$SKIP_CONTROLLER_GPU_OPERATOR"
     fi
     
+    # Controller cluster: Envoy Gateway
+    # The controller already gets its own Envoy during controller install. When the
+    # controller is not being (re)installed in this run (e.g. --register-worker),
+    # skip re-touching the controller's Envoy to avoid needless upgrade/cert-gen churn.
+    CONTROLLER_SKIP_ENVOY="$SKIP_CONTROLLER_ENVOY"
+    if [ "$SKIP_CONTROLLER" = "true" ]; then
+        CONTROLLER_SKIP_ENVOY="true"
+    fi
+
     # Worker clusters: Use worker-specific flags only
     WORKER_SKIP_PROMETHEUS="$SKIP_WORKER_PROMETHEUS"
     WORKER_SKIP_GPU_OPERATOR="$SKIP_WORKER_GPU_OPERATOR"
+    WORKER_SKIP_ENVOY="$SKIP_WORKER_ENVOY"
     
     # Update controller cluster prerequisites (index 0 in additional_apps for each type)
     # PostgreSQL is ONLY on controller cluster
@@ -1725,6 +1754,13 @@ if [ "$MULTI_CLUSTER" = "true" ] && [ ${#WORKER_KUBECONFIG_RELATIVES[@]} -gt 0 ]
         yq eval '(.additional_apps[] | select(.name == "gpu-operator") | .skip_installation) = true' -i egs-installer-config.yaml
         print_warning "GPU Operator installation will be skipped on controller cluster"
     fi
+
+    # Skip the controller (template) envoy-gateway entry when requested / not installing controller
+    if [ "$CONTROLLER_SKIP_ENVOY" = "true" ]; then
+        yq eval '(.additional_apps | to_entries | map(select(.value.name == "envoy-gateway"))[0].key) as $idx | .additional_apps[$idx].skip_installation = true' -i egs-installer-config.yaml 2>/dev/null || \
+        yq eval '(.additional_apps[] | select(.name == "envoy-gateway") | .skip_installation) = true' -i egs-installer-config.yaml
+        print_warning "Envoy Gateway installation will be skipped on controller cluster"
+    fi
     
     # Get current counts for additional_apps, manifests, and commands
     CURRENT_ADDITIONAL_APPS_COUNT=$(yq eval '.additional_apps | length' egs-installer-config.yaml 2>/dev/null || echo "3")
@@ -1734,6 +1770,7 @@ if [ "$MULTI_CLUSTER" = "true" ] && [ ${#WORKER_KUBECONFIG_RELATIVES[@]} -gt 0 ]
     # Find template indices for gpu-operator and prometheus in additional_apps (from repo config)
     GPU_OP_TEMPLATE_IDX=$(yq eval '.additional_apps | to_entries | map(select(.value.name == "gpu-operator"))[0].key // 0' egs-installer-config.yaml 2>/dev/null || echo "0")
     PROM_TEMPLATE_IDX=$(yq eval '.additional_apps | to_entries | map(select(.value.name == "prometheus"))[0].key // 1' egs-installer-config.yaml 2>/dev/null || echo "1")
+    ENVOY_TEMPLATE_IDX=$(yq eval '.additional_apps | to_entries | map(select(.value.name == "envoy-gateway"))[0].key // 2' egs-installer-config.yaml 2>/dev/null || echo "2")
     
     # Find template indices for manifests (gpu-operator-quota and nvidia-driver-installer)
     GPU_QUOTA_TEMPLATE_IDX=$(yq eval '.manifests | to_entries | map(select(.value.appname == "gpu-operator-quota"))[0].key // 0' egs-installer-config.yaml 2>/dev/null || echo "0")
@@ -1757,7 +1794,8 @@ if [ "$MULTI_CLUSTER" = "true" ] && [ ${#WORKER_KUBECONFIG_RELATIVES[@]} -gt 0 ]
         print_info "Adding prerequisites for worker cluster: $WORKER_NAME"
         
         # ===== ADD GPU-OPERATOR FOR WORKER (copy from template) =====
-        GPU_OP_INDEX=$((CURRENT_ADDITIONAL_APPS_COUNT + i * 2))
+        # 3 additional_apps entries are added per worker: gpu-operator, prometheus, envoy-gateway
+        GPU_OP_INDEX=$((CURRENT_ADDITIONAL_APPS_COUNT + i * 3))
         
         # Copy the gpu-operator template entry to the new index
         yq eval ".additional_apps[$GPU_OP_INDEX] = .additional_apps[$GPU_OP_TEMPLATE_IDX]" -i egs-installer-config.yaml
@@ -1774,7 +1812,7 @@ if [ "$MULTI_CLUSTER" = "true" ] && [ ${#WORKER_KUBECONFIG_RELATIVES[@]} -gt 0 ]
         fi
         
         # ===== ADD PROMETHEUS FOR WORKER (copy from template) =====
-        PROM_INDEX=$((CURRENT_ADDITIONAL_APPS_COUNT + i * 2 + 1))
+        PROM_INDEX=$((CURRENT_ADDITIONAL_APPS_COUNT + i * 3 + 1))
         
         # Copy the prometheus template entry to the new index
         yq eval ".additional_apps[$PROM_INDEX] = .additional_apps[$PROM_TEMPLATE_IDX]" -i egs-installer-config.yaml
@@ -1788,6 +1826,25 @@ if [ "$MULTI_CLUSTER" = "true" ] && [ ${#WORKER_KUBECONFIG_RELATIVES[@]} -gt 0 ]
             print_warning "Prometheus will be skipped on worker: $WORKER_NAME"
         else
             print_success "Added Prometheus for worker: $WORKER_NAME (copied from template)"
+        fi
+
+        # ===== ADD ENVOY GATEWAY FOR WORKER (copy from template) =====
+        # Required by the kubeslice worker-operator (EnvoyProxy CRD). Installing it on
+        # each worker prevents the operator from crash-looping on missing CRDs.
+        ENVOY_INDEX=$((CURRENT_ADDITIONAL_APPS_COUNT + i * 3 + 2))
+
+        # Copy the envoy-gateway template entry to the new index
+        yq eval ".additional_apps[$ENVOY_INDEX] = .additional_apps[$ENVOY_TEMPLATE_IDX]" -i egs-installer-config.yaml
+        # Update only the kubeconfig-related fields so it targets the worker cluster
+        yq eval ".additional_apps[$ENVOY_INDEX].use_global_kubeconfig = false" -i egs-installer-config.yaml
+        yq eval ".additional_apps[$ENVOY_INDEX].kubeconfig = \"$WORKER_KUBECONFIG_RELATIVE\"" -i egs-installer-config.yaml
+        yq eval ".additional_apps[$ENVOY_INDEX].kubecontext = \"$WORKER_CTX\"" -i egs-installer-config.yaml
+        yq eval ".additional_apps[$ENVOY_INDEX].skip_installation = $WORKER_SKIP_ENVOY" -i egs-installer-config.yaml
+
+        if [ "$WORKER_SKIP_ENVOY" = "true" ]; then
+            print_warning "Envoy Gateway will be skipped on worker: $WORKER_NAME"
+        else
+            print_success "Added Envoy Gateway for worker: $WORKER_NAME (copied from template)"
         fi
         
         # ===== ADD MANIFESTS FOR WORKER (GPU Operator Quota - copy from template) =====


### PR DESCRIPTION
## Summary
- Sync `install-egs.sh` from `main` (PR #309) so `curl https://repo.egs.avesha.io/install-egs.sh` installs Envoy Gateway on each worker automatically.
- Sync `docs/Quick-Install-README.md` Envoy documentation updates.
- Keep all doc cross-links as `.html` for the gh-pages Jekyll site.
- Correct Full Installation Guide link: `../README.md#getting-started` → `../README.html#getting-started`.
## Notes
- `egs-installer.sh` was not changed in PR #309 and is already current on gh-pages from PR #308.
## Test plan
- [ ] Confirm PR targets `gh-pages`
- [ ] After merge, `curl -fsSL https://repo.egs.avesha.io/install-egs.sh | grep -c skip-worker-envoy` returns > 0
- [ ] Confirm Quick-Install page links still resolve as `.html`