### PR TITLE
fix(envoy): tolerate EGS dedicated-node taint so certgen hook can schedule

### DIFF
--- a/charts/gateway-helm/values.yaml
+++ b/charts/gateway-helm/values.yaml
@@ -78,7 +78,14 @@ deployment:
       prometheus.io/port: '19001'
     labels: {}
     topologySpreadConstraints: []
-    tolerations: []
+    # EGS worker nodes are tainted (e.g. kubeslice.io/egs=dedicated-node:NoSchedule),
+    # so Envoy Gateway must tolerate them or it stays Pending.
+    tolerations:
+      - operator: "Exists"
+      - key: "kubeslice.io/egs"
+        operator: "Equal"
+        value: "dedicated-node"
+        effect: "NoSchedule"
     nodeSelector: {}
 
 service:
@@ -120,7 +127,15 @@ certgen:
       labels: {}
     resources: {}
     affinity: {}
-    tolerations: []
+    # The certgen Job runs as a Helm pre-install/pre-upgrade hook. Without these
+    # tolerations it cannot schedule on tainted EGS nodes and the hook times out
+    # with "failed pre-install: timed out waiting for the condition".
+    tolerations:
+      - operator: "Exists"
+      - key: "kubeslice.io/egs"
+        operator: "Equal"
+        value: "dedicated-node"
+        effect: "NoSchedule"
     nodeSelector: {}
     ttlSecondsAfterFinished: 30
     securityContext:


### PR DESCRIPTION
## Problem
On Telenor z4/z2 the worker install failed with:
`failed pre-install: 1 error occurred: * timed out waiting for the condition`
Root cause (confirmed live on z4 / hpz4):
- Node taint: `kubeslice.io/egs=dedicated-node:NoSchedule`
- `eg-gateway-helm-certgen` pod `Pending` with `FailedScheduling: 1 node(s) had untolerated taint(s)`
- `certgen` is a Helm `pre-install, pre-upgrade` hook, so Helm waited 300s and failed
- `charts/gateway-helm` had `tolerations: []` for certgen.job and deployment.pod, unlike every other EGS worker component
Note: the EnvoyProxy CRD still landed (Helm applies `crds/` before hooks), so PR #309's benefit held and `kubeslice-operator` stopped crash-looping. Only the `eg` release failed.
## Fix
- `charts/gateway-helm/values.yaml`: add EGS tolerations to `certgen.job.tolerations` and `deployment.pod.tolerations`
- Chart-only is sufficient — installer passes `inline_values` via `helm -f` (merge), which does not override these defaults, and this covers `--preserve-config` customer configs as well
## Validation
- `helm template` (with real unmodified installer `inline_values` via `-f`) renders tolerations on both the certgen Job and the Deployment
- Applied Telenor's exact taint on a lab worker: pre-fix certgen `Pending` with the identical FailedScheduling event; post-fix certgen scheduled and `Completed` in 4s
- Lab restored (taint removed, test Jobs deleted); Telenor was read-only
## Notes
- `install-egs.sh` and `egs-installer-config.yaml` unchanged, so no gh-pages sync required (installer clones `main`)
## Test plan
- [ ] Re-run worker install on a tainted worker and confirm `eg` reaches `deployed`
- [ ] Confirm `envoy-gateway` pod Running on the tainted node